### PR TITLE
Implement basic skladchina models and routes

### DIFF
--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class DashboardController extends Controller
+{
+    public function index()
+    {
+        return view('admin.dashboard');
+    }
+}

--- a/app/Http/Controllers/SkladchinaController.php
+++ b/app/Http/Controllers/SkladchinaController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Skladchina;
+use App\Models\Category;
+use Illuminate\Support\Facades\Auth;
+
+class SkladchinaController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $skladchinas = Skladchina::with('category', 'organizer')->paginate();
+        return view('skladchinas.index', compact('skladchinas'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        $categories = Category::all();
+        return view('skladchinas.create', compact('categories'));
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string',
+            'description' => 'nullable|string',
+            'full_price' => 'required|numeric',
+            'member_price' => 'required|numeric',
+            'category_id' => 'required|exists:categories,id',
+        ]);
+
+        $data['organizer_id'] = Auth::id();
+
+        Skladchina::create($data);
+
+        return redirect()->route('skladchinas.index');
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        $skladchina = Skladchina::with('category', 'organizer', 'participants')->findOrFail($id);
+        return view('skladchinas.show', compact('skladchina'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        $skladchina = Skladchina::findOrFail($id);
+        $categories = Category::all();
+        return view('skladchinas.edit', compact('skladchina', 'categories'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        $skladchina = Skladchina::findOrFail($id);
+        $data = $request->validate([
+            'name' => 'required|string',
+            'description' => 'nullable|string',
+            'full_price' => 'required|numeric',
+            'member_price' => 'required|numeric',
+            'category_id' => 'required|exists:categories,id',
+        ]);
+        $skladchina->update($data);
+        return redirect()->route('skladchinas.show', $skladchina);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        $skladchina = Skladchina::findOrFail($id);
+        $skladchina->delete();
+        return redirect()->route('skladchinas.index');
+    }
+}

--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RoleMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next, ...$roles): Response
+    {
+        $roles = array_filter($roles);
+
+        if ($roles && ! in_array($request->user()?->role, $roles, true)) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Category extends Model
+{
+    protected $fillable = [
+        'name',
+        'slug',
+        'description',
+        'parent_id',
+    ];
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_id');
+    }
+}

--- a/app/Models/Skladchina.php
+++ b/app/Models/Skladchina.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Skladchina extends Model
+{
+    protected $fillable = [
+        'name',
+        'description',
+        'cover',
+        'full_price',
+        'member_price',
+        'status',
+        'attachment',
+        'organizer_id',
+        'category_id',
+    ];
+
+    public function organizer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'organizer_id');
+    }
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
+
+    public function participants(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class)->withTimestamps();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,10 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'auth' => Illuminate\Auth\Middleware\Authenticate::class,
+            'role' => App\Http\Middleware\RoleMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -28,6 +28,7 @@ class UserFactory extends Factory
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
+            'role' => 'user',
             'remember_token' => Str::random(10),
         ];
     }

--- a/database/migrations/2025_06_04_221836_add_role_to_users_table.php
+++ b/database/migrations/2025_06_04_221836_add_role_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('role')->default('user');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/database/migrations/2025_06_04_221848_create_categories_table.php
+++ b/database/migrations/2025_06_04_221848_create_categories_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('parent_id')->nullable()->constrained('categories')->nullOnDelete();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2025_06_04_221859_create_skladchinas_table.php
+++ b/database/migrations/2025_06_04_221859_create_skladchinas_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('skladchinas', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->string('cover')->nullable();
+            $table->decimal('full_price', 10, 2);
+            $table->decimal('member_price', 10, 2);
+            $table->string('status')->default('draft');
+            $table->text('attachment')->nullable();
+            $table->foreignId('organizer_id')->constrained('users');
+            $table->foreignId('category_id')->constrained('categories');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('skladchinas');
+    }
+};

--- a/database/migrations/2025_06_04_221907_create_skladchina_user_table.php
+++ b/database/migrations/2025_06_04_221907_create_skladchina_user_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('skladchina_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('skladchina_id')->constrained('skladchinas')->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->timestamps();
+            $table->unique(['skladchina_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('skladchina_user');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,11 +13,16 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
         User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'password' => bcrypt('password'),
+            'role' => 'admin',
+        ]);
+
+        \App\Models\Category::create([
+            'name' => 'Общее',
+            'slug' => 'general',
         ]);
     }
 }

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,0 +1,4 @@
+{
+  "resources/css/app.css": {"file":"app.css","src":"resources/css/app.css"},
+  "resources/js/app.js": {"file":"app.js","src":"resources/js/app.js"}
+}

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,3 @@
+<x-app-layout>
+    <h1 class="text-xl font-bold">Админ панель</h1>
+</x-app-layout>

--- a/resources/views/skladchinas/create.blade.php
+++ b/resources/views/skladchinas/create.blade.php
@@ -1,0 +1,16 @@
+<x-app-layout>
+    <h1 class="text-xl font-bold mb-4">Новая складчина</h1>
+    <form method="POST" action="{{ route('skladchinas.store') }}">
+        @csrf
+        <input type="text" name="name" placeholder="Название" class="border p-2 block mb-2" />
+        <textarea name="description" class="border p-2 block mb-2" placeholder="Описание"></textarea>
+        <input type="number" step="0.01" name="full_price" placeholder="Полная цена" class="border p-2 block mb-2" />
+        <input type="number" step="0.01" name="member_price" placeholder="Цена взноса" class="border p-2 block mb-2" />
+        <select name="category_id" class="border p-2 block mb-2">
+            @foreach($categories as $cat)
+                <option value="{{ $cat->id }}">{{ $cat->name }}</option>
+            @endforeach
+        </select>
+        <x-primary-button>Создать</x-primary-button>
+    </form>
+</x-app-layout>

--- a/resources/views/skladchinas/edit.blade.php
+++ b/resources/views/skladchinas/edit.blade.php
@@ -1,0 +1,17 @@
+<x-app-layout>
+    <h1 class="text-xl font-bold mb-4">Редактировать складчину</h1>
+    <form method="POST" action="{{ route('skladchinas.update', $skladchina) }}">
+        @csrf
+        @method('PUT')
+        <input type="text" name="name" value="{{ $skladchina->name }}" class="border p-2 block mb-2" />
+        <textarea name="description" class="border p-2 block mb-2">{{ $skladchina->description }}</textarea>
+        <input type="number" step="0.01" name="full_price" value="{{ $skladchina->full_price }}" class="border p-2 block mb-2" />
+        <input type="number" step="0.01" name="member_price" value="{{ $skladchina->member_price }}" class="border p-2 block mb-2" />
+        <select name="category_id" class="border p-2 block mb-2">
+            @foreach($categories as $cat)
+                <option value="{{ $cat->id }}" @selected($skladchina->category_id == $cat->id)>{{ $cat->name }}</option>
+            @endforeach
+        </select>
+        <x-primary-button>Сохранить</x-primary-button>
+    </form>
+</x-app-layout>

--- a/resources/views/skladchinas/index.blade.php
+++ b/resources/views/skladchinas/index.blade.php
@@ -1,0 +1,11 @@
+<x-app-layout>
+    <h1 class="text-xl font-bold mb-4">Складчины</h1>
+    <a href="{{ route('skladchinas.create') }}" class="text-blue-500">Создать</a>
+    <ul class="mt-4">
+        @foreach($skladchinas as $skladchina)
+            <li>
+                <a href="{{ route('skladchinas.show', $skladchina) }}">{{ $skladchina->name }}</a>
+            </li>
+        @endforeach
+    </ul>
+</x-app-layout>

--- a/resources/views/skladchinas/show.blade.php
+++ b/resources/views/skladchinas/show.blade.php
@@ -1,0 +1,5 @@
+<x-app-layout>
+    <h1 class="text-xl font-bold mb-4">{{ $skladchina->name }}</h1>
+    <p>{{ $skladchina->description }}</p>
+    <p>Цена: {{ $skladchina->member_price }}</p>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\SkladchinaController;
+use App\Http\Controllers\Admin\DashboardController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -15,6 +17,13 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+});
+
+Route::resource('skladchinas', SkladchinaController::class);
+
+Route::middleware(['auth', 'role:admin,moderator'])->prefix('admin')->name('admin.')->group(function () {
+    Route::get('/', [DashboardController::class, 'index'])->name('dashboard');
+    Route::resource('skladchinas', SkladchinaController::class)->except(['show']);
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- add role field to users and seed an admin account
- add categories and skladchinas models/migrations
- add role middleware and register it
- create simple CRUD controller and views for skladchinas
- seed default category and admin
- provide placeholder vite manifest for tests

## Testing
- `php artisan migrate --seed --force`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6840c5ca62fc83289824882654c308f0