### PR TITLE
Improve skladchina frontend

### DIFF
--- a/app/Http/Controllers/SkladchinaController.php
+++ b/app/Http/Controllers/SkladchinaController.php
@@ -35,10 +35,15 @@ class SkladchinaController extends Controller
         $data = $request->validate([
             'name' => 'required|string',
             'description' => 'nullable|string',
+            'image' => 'nullable|image',
             'full_price' => 'required|numeric',
             'member_price' => 'required|numeric',
             'category_id' => 'required|exists:categories,id',
         ]);
+
+        if ($request->hasFile('image')) {
+            $data['image_path'] = $request->file('image')->store('covers', 'public');
+        }
 
         $data['organizer_id'] = Auth::id();
 
@@ -86,10 +91,15 @@ class SkladchinaController extends Controller
         $data = $request->validate([
             'name' => 'required|string',
             'description' => 'nullable|string',
+            'image' => 'nullable|image',
             'full_price' => 'required|numeric',
             'member_price' => 'required|numeric',
             'category_id' => 'required|exists:categories,id',
         ]);
+        if ($request->hasFile('image')) {
+            $data['image_path'] = $request->file('image')->store('covers', 'public');
+        }
+
         $skladchina->update($data);
         return redirect()->route('skladchinas.show', $skladchina);
     }

--- a/app/Models/Skladchina.php
+++ b/app/Models/Skladchina.php
@@ -12,6 +12,7 @@ class Skladchina extends Model
         'name',
         'description',
         'cover',
+        'image_path',
         'full_price',
         'member_price',
         'status',

--- a/database/migrations/2025_06_04_222000_add_image_path_to_skladchinas_table.php
+++ b/database/migrations/2025_06_04_222000_add_image_path_to_skladchinas_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('skladchinas', function (Blueprint $table) {
+            $table->string('image_path')->nullable()->after('cover');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('skladchinas', function (Blueprint $table) {
+            $table->dropColumn('image_path');
+        });
+    }
+};

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -6,19 +6,29 @@
     </x-slot>
 
     <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <h3 class="font-bold mb-4">Профиль</h3>
+                <p class="mb-1">Имя: {{ auth()->user()->name }}</p>
+                <p class="mb-1">Email: {{ auth()->user()->email }}</p>
+                <p class="mb-1">Роль: {{ auth()->user()->role }}</p>
+            </div>
+
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
                 <h3 class="font-bold mb-4">Мои складчины</h3>
-                <ul>
+                <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
                     @forelse($skladchinas as $item)
-                        <li class="mb-2">
-                            <a href="{{ route('skladchinas.show', $item) }}">{{ $item->name }}</a>
-                            <span class="text-sm text-gray-500">({{ $item->category->name }})</span>
-                        </li>
+                        <div class="border p-4 rounded shadow">
+                            @if($item->image_path)
+                                <img src="{{ asset('storage/'.$item->image_path) }}" alt="{{ $item->name }}" class="mb-2 w-full h-40 object-cover rounded">
+                            @endif
+                            <a href="{{ route('skladchinas.show', $item) }}" class="font-semibold">{{ $item->name }}</a>
+                            <p class="text-sm text-gray-500">{{ $item->category->name }}</p>
+                        </div>
                     @empty
-                        <li>Вы пока не участвуете в складчинах.</li>
+                        <p>Вы пока не участвуете в складчинах.</p>
                     @endforelse
-                </ul>
+                </div>
             </div>
         </div>
     </div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -4,13 +4,13 @@
         <h2 class="text-lg font-semibold mt-4">{{ $category->name }}</h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-2">
             @foreach($category->skladchinas as $skladchina)
-                <div class="border p-4 rounded">
+                <div class="border p-4 rounded shadow">
+                    @if($skladchina->image_path)
+                        <img src="{{ asset('storage/'.$skladchina->image_path) }}" alt="{{ $skladchina->name }}" class="mb-2 w-full h-40 object-cover rounded">
+                    @endif
                     <h3 class="font-bold">{{ $skladchina->name }}</h3>
                     <p class="text-sm mb-1">{{ $skladchina->description }}</p>
                     <p class="text-sm">Цена: {{ $skladchina->full_price }} | Взнос: {{ $skladchina->member_price }}</p>
-                    @if($skladchina->cover)
-                        <img src="{{ asset('storage/'.$skladchina->cover) }}" alt="{{ $skladchina->name }}" class="mt-2 w-full h-40 object-cover">
-                    @endif
                     @auth
                         @if(! $skladchina->participants->contains(Auth::id()))
                             <form method="POST" action="{{ route('skladchinas.join', $skladchina) }}" class="mt-2">

--- a/resources/views/skladchinas/create.blade.php
+++ b/resources/views/skladchinas/create.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
     <h1 class="text-xl font-bold mb-4">Новая складчина</h1>
-    <form method="POST" action="{{ route('skladchinas.store') }}">
+    <form method="POST" action="{{ route('skladchinas.store') }}" enctype="multipart/form-data">
         @csrf
         <input type="text" name="name" placeholder="Название" class="border p-2 block mb-2" />
         <textarea name="description" class="border p-2 block mb-2" placeholder="Описание"></textarea>
@@ -11,6 +11,7 @@
                 <option value="{{ $cat->id }}">{{ $cat->name }}</option>
             @endforeach
         </select>
+        <input type="file" name="image" class="border p-2 block mb-2" />
         <x-primary-button>Создать</x-primary-button>
     </form>
 </x-app-layout>

--- a/resources/views/skladchinas/edit.blade.php
+++ b/resources/views/skladchinas/edit.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
     <h1 class="text-xl font-bold mb-4">Редактировать складчину</h1>
-    <form method="POST" action="{{ route('skladchinas.update', $skladchina) }}">
+    <form method="POST" action="{{ route('skladchinas.update', $skladchina) }}" enctype="multipart/form-data">
         @csrf
         @method('PUT')
         <input type="text" name="name" value="{{ $skladchina->name }}" class="border p-2 block mb-2" />
@@ -12,6 +12,10 @@
                 <option value="{{ $cat->id }}" @selected($skladchina->category_id == $cat->id)>{{ $cat->name }}</option>
             @endforeach
         </select>
+        @if($skladchina->image_path)
+            <img src="{{ asset('storage/'.$skladchina->image_path) }}" alt="{{ $skladchina->name }}" class="mb-2 w-full h-40 object-cover rounded">
+        @endif
+        <input type="file" name="image" class="border p-2 block mb-2" />
         <x-primary-button>Сохранить</x-primary-button>
     </form>
 </x-app-layout>

--- a/resources/views/skladchinas/index.blade.php
+++ b/resources/views/skladchinas/index.blade.php
@@ -3,12 +3,18 @@
     @auth
         <a href="{{ route('skladchinas.create') }}" class="text-blue-500">Создать</a>
     @endauth
-    <ul class="mt-4">
+    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-4">
         @foreach($skladchinas as $skladchina)
-            <li class="mb-2">
-                <a href="{{ route('skladchinas.show', $skladchina) }}">{{ $skladchina->name }}</a>
-                <span class="text-sm text-gray-500">({{ $skladchina->category->name }})</span>
-            </li>
+            <div class="border rounded p-4 shadow">
+                @if($skladchina->image_path)
+                    <img src="{{ asset('storage/'.$skladchina->image_path) }}" alt="{{ $skladchina->name }}" class="mb-2 w-full h-40 object-cover rounded">
+                @endif
+                <h3 class="font-semibold text-lg">
+                    <a href="{{ route('skladchinas.show', $skladchina) }}">{{ $skladchina->name }}</a>
+                </h3>
+                <p class="text-sm text-gray-500 mb-1">{{ $skladchina->category->name }}</p>
+                <p class="text-sm">Цена: {{ $skladchina->full_price }} | Взнос: {{ $skladchina->member_price }}</p>
+            </div>
         @endforeach
-    </ul>
+    </div>
 </x-app-layout>

--- a/resources/views/skladchinas/show.blade.php
+++ b/resources/views/skladchinas/show.blade.php
@@ -1,7 +1,11 @@
 <x-app-layout>
     <h1 class="text-xl font-bold mb-4">{{ $skladchina->name }}</h1>
+    @if($skladchina->image_path)
+        <img src="{{ asset('storage/'.$skladchina->image_path) }}" alt="{{ $skladchina->name }}" class="mb-4 w-full h-64 object-cover rounded">
+    @endif
     <p>{{ $skladchina->description }}</p>
-    <p>Цена: {{ $skladchina->member_price }}</p>
+    <p class="mt-2">Полная цена: {{ $skladchina->full_price }}</p>
+    <p>Цена взноса: {{ $skladchina->member_price }}</p>
     @auth
         @if(! $skladchina->participants->contains(Auth::id()))
             <form method="POST" action="{{ route('skladchinas.join', $skladchina) }}" class="mt-4">


### PR DESCRIPTION
## Summary
- allow file upload for skladchina cover images
- record uploaded image path
- show images and better layout on home and admin lists
- redesign dashboard profile page
- include image preview on skladchina pages

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ce2b410083288fe535857c915d0c