### PR TITLE
Implement user ban management and participation list

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -11,7 +11,7 @@ class UserController extends Controller
 {
     public function index()
     {
-        $users = User::paginate();
+        $users = User::withCount('skladchinas')->paginate();
         return view('admin.users.index', compact('users'));
     }
 
@@ -30,7 +30,10 @@ class UserController extends Controller
             'email' => 'required|email|unique:users,email,' . $user->id,
             'role' => 'required|string',
             'password' => 'nullable|string|min:6',
+            'banned' => 'boolean',
         ]);
+
+        $data['banned'] = $request->boolean('banned');
 
         if (!empty($data['password'])) {
             $data['password'] = Hash::make($data['password']);
@@ -49,5 +52,20 @@ class UserController extends Controller
         $user->delete();
 
         return redirect()->route('admin.users.index');
+    }
+
+    public function toggleBan(User $user)
+    {
+        $user->banned = ! $user->banned;
+        $user->save();
+
+        return back();
+    }
+
+    public function participations(User $user)
+    {
+        $skladchinas = $user->skladchinas()->with('category')->get();
+
+        return view('admin.users.participations', compact('user', 'skladchinas'));
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,6 +23,7 @@ class User extends Authenticatable
         'email',
         'password',
         'role',
+        'banned',
     ];
 
     /**
@@ -45,6 +46,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'banned' => 'boolean',
         ];
     }
 

--- a/database/migrations/2025_06_04_222100_add_banned_to_users_table.php
+++ b/database/migrations/2025_06_04_222100_add_banned_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('banned')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('banned');
+        });
+    }
+};

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -13,6 +13,10 @@
             <option value="moderator" @selected($user->role==='moderator')>moderator</option>
             <option value="admin" @selected($user->role==='admin')>admin</option>
         </select>
+        <label class="flex items-center space-x-2">
+            <input type="checkbox" name="banned" value="1" @checked($user->banned) class="rounded">
+            <span>Забанен</span>
+        </label>
         <x-primary-button class="mt-2">Сохранить</x-primary-button>
     </form>
 @endsection

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -1,22 +1,94 @@
 @extends('layouts.admin')
 
 @section('content')
-    <h1 class="text-2xl font-semibold mb-6 border-b pb-2">Пользователи</h1>
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-        @foreach($users as $user)
-            <div class="bg-white dark:bg-gray-700 shadow rounded-lg p-4">
-                <h3 class="text-lg font-bold text-gray-800 dark:text-gray-100">{{ $user->name }}</h3>
-                <p class="text-sm text-gray-600 dark:text-gray-300">{{ $user->email }}</p>
-                <p class="text-sm text-gray-500 dark:text-gray-400">Роль: {{ $user->role }}</p>
-                <div class="flex justify-between mt-4">
-                    <a href="{{ route('admin.users.edit', $user) }}" class="text-blue-600 hover:underline">Редактировать</a>
-                    <form method="POST" action="{{ route('admin.users.destroy', $user) }}">
-                        @csrf
-                        @method('DELETE')
-                        <button type="submit" class="text-red-500 hover:underline">Удалить</button>
-                    </form>
+<div class="max-w-7xl mx-auto px-4 py-8">
+    <h1 class="text-2xl font-semibold text-gray-800 dark:text-gray-200 mb-6">Пользователи</h1>
+
+    <div class="bg-white dark:bg-gray-800 overflow-hidden shadow rounded-lg">
+        <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead class="bg-gray-50 dark:bg-gray-900">
+                <tr>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                        Имя
+                    </th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                        Email
+                    </th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                        Роль
+                    </th>
+                    <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                        Складчины
+                    </th>
+                    <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                        Действия
+                    </th>
+                </tr>
+            </thead>
+            <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                @foreach($users as $user)
+                    <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                        <td class="px-6 py-4 whitespace-nowrap">
+                            <div class="text-sm font-medium text-gray-900 dark:text-gray-100">
+                                {{ $user->name }}
+                            </div>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap">
+                            <div class="text-sm text-gray-700 dark:text-gray-300">
+                                {{ $user->email }}
+                            </div>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap">
+                            <span class="inline-flex px-2 py-1 text-xs font-semibold leading-5 rounded-full
+                                {{ $user->role === 'admin' ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200'
+                                : ($user->role === 'moderator' ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200'
+                                : 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200') }}">
+                                {{ ucfirst($user->role) }}
+                            </span>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-center text-sm">
+                            <a href="{{ route('admin.users.participations', $user) }}" class="text-blue-600 dark:text-blue-400 hover:underline">
+                                {{ $user->skladchinas_count }}
+                            </a>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                            <a href="{{ route('admin.users.edit', $user) }}" class="text-blue-600 dark:text-blue-400 hover:underline">Редактировать</a>
+                            <form action="{{ route('admin.users.toggleBan', $user) }}" method="POST" class="inline">
+                                @csrf
+                                @method('PATCH')
+                                <button type="submit" class="text-{{ $user->banned ? 'green' : 'yellow' }}-600 dark:text-{{ $user->banned ? 'green' : 'yellow' }}-400 hover:underline">
+                                    {{ $user->banned ? 'Разбанить' : 'Забанить' }}
+                                </button>
+                            </form>
+                            <form action="{{ route('admin.users.destroy', $user) }}" method="POST" class="inline">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" onclick="return confirm('Удалить пользователя {{ $user->name }}?')" class="text-red-600 dark:text-red-400 hover:underline">Удалить</button>
+                            </form>
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+
+        <div class="px-4 py-3 bg-gray-50 dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between">
+            <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+                <div>
+                    <p class="text-sm text-gray-700 dark:text-gray-300">
+                        Показано
+                        <span class="font-medium">{{ $users->firstItem() }}</span>
+                        –
+                        <span class="font-medium">{{ $users->lastItem() }}</span>
+                        из
+                        <span class="font-medium">{{ $users->total() }}</span>
+                        пользователей
+                    </p>
+                </div>
+                <div>
+                    {{ $users->links() }}
                 </div>
             </div>
-        @endforeach
+        </div>
     </div>
+</div>
 @endsection

--- a/resources/views/admin/users/participations.blade.php
+++ b/resources/views/admin/users/participations.blade.php
@@ -1,0 +1,25 @@
+@extends('layouts.admin')
+
+@section('content')
+<div class="max-w-7xl mx-auto px-4 py-8">
+    <h1 class="text-2xl font-semibold text-gray-800 dark:text-gray-200 mb-6">Складчины пользователя {{ $user->name }}</h1>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        @forelse($skladchinas as $skladchina)
+            <div class="bg-white dark:bg-gray-700 rounded-xl shadow-md overflow-hidden">
+                @if($skladchina->image_path)
+                    <img src="{{ asset('storage/'.$skladchina->image_path) }}" class="w-full h-40 object-cover" />
+                @endif
+                <div class="p-4">
+                    <h2 class="text-xl font-semibold text-gray-800 dark:text-gray-100">{{ $skladchina->name }}</h2>
+                    <p class="text-sm text-gray-600 dark:text-gray-300 mt-1">{{ $skladchina->category->name ?? '' }}</p>
+                    <p class="text-sm mt-2">Цена: <strong>{{ $skladchina->full_price }} ₽</strong></p>
+                    <p class="text-sm">Взнос: <strong>{{ $skladchina->member_price }} ₽</strong></p>
+                </div>
+            </div>
+        @empty
+            <p class="text-gray-600 dark:text-gray-300">Пользователь не участвует в складчинах.</p>
+        @endforelse
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,8 @@ Route::middleware(['auth', 'role:admin,moderator'])->prefix('admin')->name('admi
     Route::get('/', [DashboardController::class, 'index'])->name('dashboard');
     Route::resource('skladchinas', SkladchinaController::class)->except(['show']);
     Route::resource('categories', CategoryController::class)->except(['show']);
+    Route::patch('users/{user}/ban', [UserController::class, 'toggleBan'])->name('users.toggleBan')->middleware('role:admin');
+    Route::get('users/{user}/skladchinas', [UserController::class, 'participations'])->name('users.participations')->middleware('role:admin');
     Route::resource('users', UserController::class)->except(['show', 'create', 'store'])->middleware('role:admin');
 });
 


### PR DESCRIPTION
## Summary
- add `banned` field to users via migration
- support banning/unbanning users and list user participations
- update admin user controller and routes
- show participation count and ban button in admin list
- allow editing banned state

## Testing
- `php` and `composer` were not available so tests could not be executed

------
https://chatgpt.com/codex/tasks/task_e_6840d8a9789883289e859c3e0a5d7786