### PR TITLE
Fix category admin bug and add skladchina statuses

### DIFF
--- a/app/Http/Controllers/SkladchinaController.php
+++ b/app/Http/Controllers/SkladchinaController.php
@@ -40,6 +40,7 @@ class SkladchinaController extends Controller
             'full_price' => 'required|numeric',
             'member_price' => 'required|numeric',
             'category_id' => 'required|exists:categories,id',
+            'status' => 'nullable|string|in:' . implode(',', array_keys(Skladchina::statuses())),
         ]);
 
         if ($request->hasFile('image')) {
@@ -47,6 +48,7 @@ class SkladchinaController extends Controller
         }
 
         $data['organizer_id'] = Auth::id();
+        $data['status'] = $data['status'] ?? Skladchina::STATUS_DONATION;
 
         Skladchina::create($data);
 
@@ -96,11 +98,13 @@ class SkladchinaController extends Controller
             'full_price' => 'required|numeric',
             'member_price' => 'required|numeric',
             'category_id' => 'required|exists:categories,id',
+            'status' => 'nullable|string|in:' . implode(',', array_keys(Skladchina::statuses())),
         ]);
         if ($request->hasFile('image')) {
             $data['image_path'] = $request->file('image')->store('covers', 'public');
         }
 
+        $data['status'] = $data['status'] ?? Skladchina::STATUS_DONATION;
         $skladchina->update($data);
         return redirect()->route('skladchinas.show', $skladchina);
     }

--- a/app/Models/Skladchina.php
+++ b/app/Models/Skladchina.php
@@ -8,6 +8,19 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Skladchina extends Model
 {
+    public const STATUS_DONATION = 'donation';
+    public const STATUS_ISSUE = 'issue';
+    public const STATUS_AVAILABLE = 'available';
+
+    public static function statuses(): array
+    {
+        return [
+            self::STATUS_DONATION => 'Сбор донатов',
+            self::STATUS_ISSUE => 'Выдача',
+            self::STATUS_AVAILABLE => 'Доступно',
+        ];
+    }
+
     protected $fillable = [
         'name',
         'description',
@@ -34,5 +47,20 @@ class Skladchina extends Model
     public function participants(): BelongsToMany
     {
         return $this->belongsToMany(User::class)->withTimestamps();
+    }
+
+    public function getStatusLabelAttribute(): string
+    {
+        return self::statuses()[$this->status] ?? $this->status;
+    }
+
+    public function getStatusBadgeClassesAttribute(): string
+    {
+        return match ($this->status) {
+            self::STATUS_DONATION => 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200',
+            self::STATUS_ISSUE => 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
+            self::STATUS_AVAILABLE => 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+            default => 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200',
+        };
     }
 }

--- a/resources/views/admin/skladchinas/index.blade.php
+++ b/resources/views/admin/skladchinas/index.blade.php
@@ -9,6 +9,7 @@
                     <img src="{{ asset('storage/'.$skladchina->image_path) }}" class="w-full h-40 object-cover" />
                 @endif
                 <div class="p-4">
+                    <span class="inline-flex px-2 py-1 text-xs font-semibold leading-5 rounded-full mb-2 {{ $skladchina->status_badge_classes }}">{{ $skladchina->status_label }}</span>
                     <h2 class="text-xl font-semibold text-gray-800 dark:text-gray-100">{{ $skladchina->name }}</h2>
                     <p class="text-sm text-gray-600 dark:text-gray-300 mt-1">{{ Str::limit($skladchina->description, 80) }}</p>
                     <p class="text-sm mt-2">Цена: <strong>{{ $skladchina->full_price }} ₽</strong></p>

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -17,7 +17,7 @@
             @foreach($categories as $cat)
             <tr class="border-t hover:bg-gray-50 dark:border-gray-600 dark:hover:bg-gray-600/50">
                 <td class="p-3">{{ $cat->name }}</td>
-                <td class="p-3">{{ $cat->skladchiny()->count() }}</td>
+                <td class="p-3">{{ $cat->skladchinas()->count() }}</td>
                 <td class="p-3 flex space-x-2">
                     <a href="{{ route('admin.categories.edit', $cat) }}" class="text-blue-600 hover:underline">Редактировать</a>
                     <form method="POST" action="{{ route('admin.categories.destroy', $cat) }}">

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -30,6 +30,7 @@
 
                         {{-- Контент карточки --}}
                         <div class="p-5 flex flex-col justify-between h-full">
+                            <span class="inline-flex px-2 py-1 text-xs font-semibold leading-5 rounded-full mb-2 {{ $skladchina->status_badge_classes }}">{{ $skladchina->status_label }}</span>
                             {{-- Заголовок --}}
                             <h3 class="text-lg font-bold text-gray-900 dark:text-white mb-2">
                                 {{ $skladchina->name }}

--- a/resources/views/skladchinas/create.blade.php
+++ b/resources/views/skladchinas/create.blade.php
@@ -11,6 +11,11 @@
                 <option value="{{ $cat->id }}">{{ $cat->name }}</option>
             @endforeach
         </select>
+        <select name="status" class="border p-2 block mb-2">
+            @foreach(\App\Models\Skladchina::statuses() as $value => $label)
+                <option value="{{ $value }}">{{ $label }}</option>
+            @endforeach
+        </select>
         <input type="file" name="image" class="border p-2 block mb-2" />
         <x-primary-button>Создать</x-primary-button>
     </form>

--- a/resources/views/skladchinas/edit.blade.php
+++ b/resources/views/skladchinas/edit.blade.php
@@ -12,6 +12,11 @@
                 <option value="{{ $cat->id }}" @selected($skladchina->category_id == $cat->id)>{{ $cat->name }}</option>
             @endforeach
         </select>
+        <select name="status" class="border p-2 block mb-2">
+            @foreach(\App\Models\Skladchina::statuses() as $value => $label)
+                <option value="{{ $value }}" @selected($skladchina->status == $value)>{{ $label }}</option>
+            @endforeach
+        </select>
         @if($skladchina->image_path)
             <img src="{{ asset('storage/'.$skladchina->image_path) }}" alt="{{ $skladchina->name }}" class="mb-2 w-full h-40 object-cover rounded">
         @endif

--- a/resources/views/skladchinas/index.blade.php
+++ b/resources/views/skladchinas/index.blade.php
@@ -9,6 +9,7 @@
                 @if($skladchina->image_path)
                     <img src="{{ asset('storage/'.$skladchina->image_path) }}" alt="{{ $skladchina->name }}" class="mb-2 w-full h-40 object-cover rounded">
                 @endif
+                <span class="inline-flex px-2 py-1 text-xs font-semibold leading-5 rounded-full mb-2 {{ $skladchina->status_badge_classes }}">{{ $skladchina->status_label }}</span>
                 <h3 class="font-semibold text-lg">
                     <a href="{{ route('skladchinas.show', $skladchina) }}">{{ $skladchina->name }}</a>
                 </h3>

--- a/resources/views/skladchinas/show.blade.php
+++ b/resources/views/skladchinas/show.blade.php
@@ -17,6 +17,7 @@
                         {{ $skladchina->category->name }}
                     </span>
                 @endif
+                <span class="inline-flex px-2 py-1 text-xs font-semibold leading-5 rounded-full mb-3 {{ $skladchina->status_badge_classes }}">{{ $skladchina->status_label }}</span>
 
                 <h1 class="text-2xl sm:text-3xl font-extrabold text-gray-900 dark:text-white">
                     {{ $skladchina->name }}


### PR DESCRIPTION
## Summary
- fix call to relation on category index view
- add status constants and accessors for Skladchina
- validate and store status in controller
- display status labels in all skladchina cards
- add status field to create and edit forms

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840daa3dd70832881ca2c39224840d4