### PR TITLE
Implement balance and access renewal

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -31,9 +31,13 @@ class UserController extends Controller
             'role' => 'required|string',
             'password' => 'nullable|string|min:6',
             'banned' => 'boolean',
+            'balance' => 'nullable|numeric',
         ]);
 
         $data['banned'] = $request->boolean('banned');
+        if ($request->has('balance')) {
+            $data['balance'] = $request->input('balance');
+        }
 
         if (!empty($data['password'])) {
             $data['password'] = Hash::make($data['password']);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -24,6 +24,7 @@ class User extends Authenticatable
         'password',
         'role',
         'banned',
+        'balance',
     ];
 
     /**
@@ -47,6 +48,7 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'banned' => 'boolean',
+            'balance' => 'decimal:2',
         ];
     }
 
@@ -54,6 +56,6 @@ class User extends Authenticatable
     {
         return $this->belongsToMany(Skladchina::class)
             ->withTimestamps()
-            ->withPivot('paid');
+            ->withPivot('paid', 'access_until');
     }
 }

--- a/database/migrations/2025_06_05_001718_add_balance_to_users_table.php
+++ b/database/migrations/2025_06_05_001718_add_balance_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->decimal('balance', 10, 2)->default(0)->after('banned');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('balance');
+        });
+    }
+};

--- a/database/migrations/2025_06_05_001720_add_access_until_to_skladchina_user_table.php
+++ b/database/migrations/2025_06_05_001720_add_access_until_to_skladchina_user_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('skladchina_user', function (Blueprint $table) {
+            $table->timestamp('access_until')->nullable()->after('paid');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('skladchina_user', function (Blueprint $table) {
+            $table->dropColumn('access_until');
+        });
+    }
+};

--- a/resources/views/admin/skladchinas/participants.blade.php
+++ b/resources/views/admin/skladchinas/participants.blade.php
@@ -11,6 +11,7 @@
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Имя</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Email</th>
                     <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Оплачено</th>
+                    <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Доступ до</th>
                     <th class="px-6 py-3"></th>
                 </tr>
             </thead>
@@ -24,11 +25,20 @@
                                 {{ $participant->pivot->paid ? 'Оплачено' : 'Не оплачено' }}
                             </span>
                         </td>
-                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        <td class="px-6 py-4 whitespace-nowrap text-center text-sm text-gray-700 dark:text-gray-300">
+                            {{ $participant->pivot->access_until ? \Carbon\Carbon::parse($participant->pivot->access_until)->format('Y-m-d') : '-' }}
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
                             <form action="{{ route('admin.skladchinas.participants.toggle', [$skladchina, $participant]) }}" method="POST">
                                 @csrf
                                 @method('PATCH')
                                 <button type="submit" class="text-blue-600 dark:text-blue-400 hover:underline">Переключить</button>
+                            </form>
+                            <form action="{{ route('admin.skladchinas.participants.access', [$skladchina, $participant]) }}" method="POST" class="inline">
+                                @csrf
+                                @method('PATCH')
+                                <input type="date" name="access_until" value="{{ $participant->pivot->access_until ? \Carbon\Carbon::parse($participant->pivot->access_until)->format('Y-m-d') : '' }}" class="border rounded p-1 text-xs">
+                                <button type="submit" class="text-blue-600 dark:text-blue-400 hover:underline ml-2">Сохранить</button>
                             </form>
                         </td>
                     </tr>

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -13,6 +13,7 @@
             <option value="moderator" @selected($user->role==='moderator')>moderator</option>
             <option value="admin" @selected($user->role==='admin')>admin</option>
         </select>
+        <input type="number" step="0.01" name="balance" value="{{ $user->balance }}" class="w-full border rounded p-2" placeholder="Баланс" />
         <label class="flex items-center space-x-2">
             <input type="checkbox" name="banned" value="1" @checked($user->banned) class="rounded">
             <span>Забанен</span>

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -17,6 +17,9 @@
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Роль
                     </th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                        Баланс
+                    </th>
                     <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                         Складчины
                     </th>
@@ -45,6 +48,9 @@
                                 : 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200') }}">
                                 {{ ucfirst($user->role) }}
                             </span>
+                        </td>
+                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">
+                            {{ number_format($user->balance, 2) }} ₽
                         </td>
                         <td class="px-6 py-4 whitespace-nowrap text-center text-sm">
                             <a href="{{ route('admin.users.participations', $user) }}" class="text-blue-600 dark:text-blue-400 hover:underline">

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -12,6 +12,7 @@
                 <p class="mb-1">Имя: {{ auth()->user()->name }}</p>
                 <p class="mb-1">Email: {{ auth()->user()->email }}</p>
                 <p class="mb-1">Роль: {{ auth()->user()->role }}</p>
+                <p class="mb-1">Баланс: {{ number_format(auth()->user()->balance, 2) }} ₽</p>
             </div>
 
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">

--- a/resources/views/skladchinas/show.blade.php
+++ b/resources/views/skladchinas/show.blade.php
@@ -51,10 +51,22 @@
                             </svg>
                             Вы участвуете - {{ $participant->pivot->paid ? 'оплачено' : 'не оплачено' }}
                         </span>
-                        @if($skladchina->attachment && in_array($skladchina->status, [\App\Models\Skladchina::STATUS_ISSUE, \App\Models\Skladchina::STATUS_AVAILABLE]) && $participant->pivot->paid)
-                            <div class="mt-4">
-                                <a href="{{ $skladchina->attachment }}" class="inline-flex items-center bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-400 text-white dark:text-gray-100 font-medium px-6 py-3 rounded-lg shadow-md transition" target="_blank">Ссылка на облако</a>
-                            </div>
+                        @if($participant->pivot->paid)
+                            @if($skladchina->attachment && in_array($skladchina->status, [\App\Models\Skladchina::STATUS_ISSUE, \App\Models\Skladchina::STATUS_AVAILABLE]) && (! $participant->pivot->access_until || now()->lte($participant->pivot->access_until)))
+                                <div class="mt-4">
+                                    <a href="{{ $skladchina->attachment }}" class="inline-flex items-center bg-blue-600 dark:bg-blue-500 hover:bg-blue-700 dark:hover:bg-blue-400 text-white dark:text-gray-100 font-medium px-6 py-3 rounded-lg shadow-md transition" target="_blank">Ссылка на облако</a>
+                                </div>
+                            @elseif($participant->pivot->access_until && now()->gt($participant->pivot->access_until))
+                                <form action="{{ route('skladchinas.renew', $skladchina) }}" method="POST" class="mt-4 inline-block">
+                                    @csrf
+                                    <button type="submit" class="inline-flex items-center bg-purple-600 dark:bg-purple-500 hover:bg-purple-700 dark:hover:bg-purple-400 text-white dark:text-gray-100 font-medium px-6 py-3 rounded-lg shadow-md transition">Продлить за {{ number_format($skladchina->member_price * 0.4, 0, '', ' ') }} ₽</button>
+                                </form>
+                            @endif
+                        @else
+                            <form action="{{ route('skladchinas.pay', $skladchina) }}" method="POST" class="mt-4 inline-block">
+                                @csrf
+                                <button type="submit" class="inline-flex items-center bg-green-600 dark:bg-green-500 hover:bg-green-700 dark:hover:bg-green-400 text-white dark:text-gray-100 font-medium px-6 py-3 rounded-lg shadow-md transition">Оплатить с баланса</button>
+                            </form>
                         @endif
                     @else
                         @auth

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,8 @@ Route::middleware('auth')->group(function () {
 });
 
 Route::middleware('auth')->post('skladchinas/{skladchina}/join', [SkladchinaController::class, 'join'])->name('skladchinas.join');
+Route::middleware('auth')->post('skladchinas/{skladchina}/pay', [SkladchinaController::class, 'pay'])->name('skladchinas.pay');
+Route::middleware('auth')->post('skladchinas/{skladchina}/renew', [SkladchinaController::class, 'renew'])->name('skladchinas.renew');
 Route::resource('skladchinas', SkladchinaController::class);
 
 Route::middleware(['auth', 'role:admin,moderator'])->prefix('admin')->name('admin.')->group(function () {
@@ -29,6 +31,7 @@ Route::middleware(['auth', 'role:admin,moderator'])->prefix('admin')->name('admi
     Route::resource('skladchinas', SkladchinaController::class)->except(['show']);
     Route::get('skladchinas/{skladchina}/participants', [SkladchinaController::class, 'participants'])->name('skladchinas.participants');
     Route::patch('skladchinas/{skladchina}/participants/{user}', [SkladchinaController::class, 'togglePaid'])->name('skladchinas.participants.toggle');
+    Route::patch('skladchinas/{skladchina}/participants/{user}/access', [SkladchinaController::class, 'updateAccess'])->name('skladchinas.participants.access');
     Route::resource('categories', CategoryController::class)->except(['show']);
     Route::patch('users/{user}/ban', [UserController::class, 'toggleBan'])->name('users.toggleBan')->middleware('role:admin');
     Route::get('users/{user}/skladchinas', [UserController::class, 'participations'])->name('users.participations')->middleware('role:admin');


### PR DESCRIPTION
## Summary
- add `balance` to users and track cloud access expiration for participants
- allow paying for participation with balance and renewing expired access
- update admin views to manage balances and access dates
- show balance in dashboard
- expose payment and renewal actions from skladchina pages

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6840e1700fd88328b847765efeddaa53