### PR TITLE
Add organizer sklads dashboard

### DIFF
--- a/app/Http/Controllers/SkladchinaController.php
+++ b/app/Http/Controllers/SkladchinaController.php
@@ -25,6 +25,15 @@ class SkladchinaController extends Controller
         return view($view, compact('skladchinas'));
     }
 
+    public function my()
+    {
+        $skladchinas = Skladchina::with('category')
+            ->where('organizer_id', Auth::id())
+            ->get();
+
+        return view('organizer.skladchinas.index', compact('skladchinas'));
+    }
+
     /**
      * Show the form for creating a new resource.
      */

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -60,6 +60,11 @@ class User extends Authenticatable
             ->withPivot('paid', 'access_until');
     }
 
+    public function organizedSkladchinas()
+    {
+        return $this->hasMany(Skladchina::class, 'organizer_id');
+    }
+
     public function transactions()
     {
         return $this->hasMany(Transaction::class);

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -15,6 +15,11 @@
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                    @if(Auth::user()?->role === 'organizer')
+                        <x-nav-link :href="route('organizer.skladchinas.index')" :active="request()->routeIs('organizer.skladchinas.*')">
+                            Мои складчины
+                        </x-nav-link>
+                    @endif
                     @if(Auth::user()?->role === 'admin' || Auth::user()?->role === 'moderator')
                         <x-nav-link :href="route('admin.dashboard')" :active="request()->routeIs('admin.*')">
                             Админ

--- a/resources/views/organizer/skladchinas/index.blade.php
+++ b/resources/views/organizer/skladchinas/index.blade.php
@@ -1,0 +1,18 @@
+<x-app-layout>
+    <h1 class="text-xl font-bold mb-4">Мои складчины</h1>
+    <a href="{{ route('skladchinas.create') }}" class="text-blue-500 mb-4 inline-block">Создать новую</a>
+    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        @forelse($skladchinas as $skladchina)
+            <div class="border p-4 rounded shadow">
+                @if($skladchina->image_path)
+                    <img src="{{ asset('storage/'.$skladchina->image_path) }}" alt="{{ $skladchina->name }}" class="mb-2 w-full h-40 object-cover rounded">
+                @endif
+                <a href="{{ route('skladchinas.show', $skladchina) }}" class="font-semibold block mb-1">{{ $skladchina->name }}</a>
+                <p class="text-sm text-gray-500 mb-2">{{ $skladchina->category->name }}</p>
+                <a href="{{ route('skladchinas.edit', $skladchina) }}" class="text-blue-500">Редактировать</a>
+            </div>
+        @empty
+            <p>Вы еще не создали ни одной складчины.</p>
+        @endforelse
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,9 @@ Route::middleware('auth')->group(function () {
 Route::middleware('auth')->post('skladchinas/{skladchina}/join', [SkladchinaController::class, 'join'])->name('skladchinas.join');
 Route::middleware('auth')->post('skladchinas/{skladchina}/pay', [SkladchinaController::class, 'pay'])->name('skladchinas.pay');
 Route::middleware('auth')->post('skladchinas/{skladchina}/renew', [SkladchinaController::class, 'renew'])->name('skladchinas.renew');
+Route::middleware(['auth', 'role:organizer'])->prefix('organizer')->name('organizer.')->group(function () {
+    Route::get('skladchinas', [SkladchinaController::class, 'my'])->name('skladchinas.index');
+});
 Route::middleware(['auth','role:admin,moderator,organizer'])->group(function () {
     Route::resource('skladchinas', SkladchinaController::class)->except(['index','show']);
 });


### PR DESCRIPTION
## Summary
- add `organizedSkladchinas` relation for users
- add `my` action in `SkladchinaController`
- route organizer's skladchinas page
- navigation link for organizers
- page to show organizer's skladchinas

## Testing
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e942fa6c83288f744c0e1603ccc7