### PR TITLE
Add view toggles in personal dashboards

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -69,7 +69,8 @@ class UserController extends Controller
     public function participations(User $user)
     {
         $skladchinas = $user->skladchinas()->with('category')->get();
+        $viewMode = request('view', 'cards');
 
-        return view('admin.users.participations', compact('user', 'skladchinas'));
+        return view('admin.users.participations', compact('user', 'skladchinas', 'viewMode'));
     }
 }

--- a/app/Http/Controllers/SkladchinaController.php
+++ b/app/Http/Controllers/SkladchinaController.php
@@ -35,7 +35,9 @@ class SkladchinaController extends Controller
             ->where('organizer_id', Auth::id())
             ->get();
 
-        return view('organizer.skladchinas.index', compact('skladchinas'));
+        $viewMode = request('view', 'cards');
+
+        return view('organizer.skladchinas.index', compact('skladchinas', 'viewMode'));
     }
 
     /**

--- a/resources/views/admin/users/participations.blade.php
+++ b/resources/views/admin/users/participations.blade.php
@@ -2,14 +2,64 @@
 
 @section('content')
 <div class="max-w-7xl mx-auto px-4 py-8">
-    <h1 class="text-2xl font-semibold text-gray-800 dark:text-gray-200 mb-6">Складчины пользователя {{ $user->name }}</h1>
-
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        @forelse($skladchinas as $skladchina)
-            <x-skladchina-card :skladchina="$skladchina" :user="$user" />
-        @empty
-            <p class="text-gray-600 dark:text-gray-300">Пользователь не участвует в складчинах.</p>
-        @endforelse
+    <div class="flex items-center justify-between mb-6">
+        <h1 class="text-2xl font-semibold text-gray-800 dark:text-gray-200">Складчины пользователя {{ $user->name }}</h1>
+        @php $toggleView = $viewMode === 'cards' ? 'table' : 'cards'; @endphp
+        <a href="{{ route('admin.users.participations', ['user' => $user, 'view' => $toggleView]) }}" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition">
+            @if($viewMode === 'cards')
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor">
+                    <path d="M3 3h14v2H3V3zm0 4h7v2H3V7zm0 4h14v2H3v-2zm0 4h7v2H3v-2z" />
+                </svg>
+                Показать таблицей
+            @else
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor">
+                    <path d="M4 3h4v4H4V3zm6 0h4v4h-4V3zm-6 6h4v4H4V9zm6 0h4v4h-4V9zm-6 6h4v4H4v-4zm6 6h4v4h-4v-4z" />
+                </svg>
+                Показать карточками
+            @endif
+        </a>
     </div>
+
+    @if($viewMode === 'cards')
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            @forelse($skladchinas as $skladchina)
+                <x-skladchina-card :skladchina="$skladchina" :user="$user" />
+            @empty
+                <p class="text-gray-600 dark:text-gray-300">Пользователь не участвует в складчинах.</p>
+            @endforelse
+        </div>
+    @else
+        <div class="overflow-x-auto bg-white dark:bg-gray-800 rounded-lg shadow">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead class="bg-gray-50 dark:bg-gray-900">
+                    <tr>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">#</th>
+                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Название</th>
+                        <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Оплачено</th>
+                        <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Доступ до</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                    @foreach($skladchinas as $index => $skladchina)
+                        @php $pivot = $skladchina->pivot; @endphp
+                        <tr>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $index + 1 }}</td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                                <a href="{{ route('skladchinas.show', $skladchina) }}" class="hover:underline">{{ $skladchina->name }}</a>
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-center">
+                                <span class="inline-block px-2 py-1 text-xs rounded-full {{ $pivot->paid ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' }}">
+                                    {{ $pivot->paid ? 'Оплачено' : 'Не оплачено' }}
+                                </span>
+                            </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-center text-sm text-gray-700 dark:text-gray-300">
+                                {{ $pivot->access_until ? \Carbon\Carbon::parse($pivot->access_until)->format('Y-m-d') : '-' }}
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @endif
 </div>
 @endsection

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -27,14 +27,65 @@
             </div>
 
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
-                <h3 class="font-bold mb-4">Мои складчины</h3>
-                <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-                    @forelse($skladchinas as $item)
-                        <x-skladchina-card :skladchina="$item" />
-                    @empty
-                        <p>Вы пока не участвуете в складчинах.</p>
-                    @endforelse
+                <div class="flex items-center justify-between mb-4">
+                    <h3 class="font-bold">Мои складчины</h3>
+                    @php $toggleView = $viewMode === 'cards' ? 'table' : 'cards'; @endphp
+                    <a href="{{ route('dashboard', ['view' => $toggleView]) }}" class="inline-flex items-center px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700">
+                        @if($viewMode === 'cards')
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" viewBox="0 0 20 20" fill="currentColor">
+                                <path d="M3 3h14v2H3V3zm0 4h7v2H3V7zm0 4h14v2H3v-2zm0 4h7v2H3v-2z" />
+                            </svg>
+                            Показать списком
+                        @else
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" viewBox="0 0 20 20" fill="currentColor">
+                                <path d="M4 3h4v4H4V3zm6 0h4v4h-4V3zm-6 6h4v4H4V9zm6 0h4v4h-4V9zm-6 6h4v4H4v-4zm6 6h4v4h-4v-4z" />
+                            </svg>
+                            Показать карточками
+                        @endif
+                    </a>
                 </div>
+
+                @if($viewMode === 'cards')
+                    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+                        @forelse($skladchinas as $item)
+                            <x-skladchina-card :skladchina="$item" />
+                        @empty
+                            <p>Вы пока не участвуете в складчинах.</p>
+                        @endforelse
+                    </div>
+                @else
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">#</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Название</th>
+                                    <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Оплачено</th>
+                                    <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Доступ до</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                @foreach($skladchinas as $index => $item)
+                                    @php $pivot = $item->pivot; @endphp
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $index + 1 }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                            <a href="{{ route('skladchinas.show', $item) }}" class="hover:underline">{{ $item->name }}</a>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-center">
+                                            <span class="inline-block px-2 py-1 text-xs rounded-full {{ $pivot->paid ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' }}">
+                                                {{ $pivot->paid ? 'Оплачено' : 'Не оплачено' }}
+                                            </span>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-center text-sm text-gray-700">
+                                            {{ $pivot->access_until ? \Carbon\Carbon::parse($pivot->access_until)->format('Y-m-d') : '-' }}
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                @endif
             </div>
         </div>
     </div>

--- a/resources/views/organizer/skladchinas/index.blade.php
+++ b/resources/views/organizer/skladchinas/index.blade.php
@@ -2,10 +2,27 @@
     <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-10">
         <div class="flex items-center justify-between mb-6">
             <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Мои складчины</h1>
-            <a href="{{ route('skladchinas.create') }}"
-               class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white dark:text-white font-semibold rounded-lg shadow hover:bg-blue-700 transition">
-                + Создать новую
-            </a>
+            <div class="flex items-center space-x-4">
+                @php $toggleView = $viewMode === 'cards' ? 'table' : 'cards'; @endphp
+                <a href="{{ route('organizer.skladchinas.index', ['view' => $toggleView]) }}"
+                   class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white dark:text-white font-semibold rounded-lg hover:bg-blue-700 transition">
+                    @if($viewMode === 'cards')
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor">
+                            <path d="M3 3h14v2H3V3zm0 4h7v2H3V7zm0 4h14v2H3v-2zm0 4h7v2H3v-2z" />
+                        </svg>
+                        Показать таблицей
+                    @else
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor">
+                            <path d="M4 3h4v4H4V3zm6 0h4v4h-4V3zm-6 6h4v4H4V9zm6 0h4v4h-4V9zm-6 6h4v4H4v-4zm6 6h4v4h-4v-4z" />
+                        </svg>
+                        Показать карточками
+                    @endif
+                </a>
+                <a href="{{ route('skladchinas.create') }}"
+                   class="inline-flex items-center px-4 py-2 bg-blue-600 dark:bg-blue-500 text-white dark:text-white font-semibold rounded-lg shadow hover:bg-blue-700 transition">
+                    + Создать новую
+                </a>
+            </div>
         </div>
 
         @if($skladchinas->isEmpty())
@@ -13,19 +30,56 @@
                 Вы ещё не создали ни одной складчины.
             </div>
         @else
-            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                @foreach($skladchinas as $skladchina)
-                    <div class="bg-white dark:bg-gray-800 rounded-2xl shadow hover:shadow-lg transition">
-                        <x-skladchina-card :skladchina="$skladchina" :user="auth()->user()" />
-                        <div class="border-t px-4 py-3 text-center">
-                            <a href="{{ route('skladchinas.edit', $skladchina) }}"
-                               class="inline-block text-sm text-blue-600 dark:text-blue-400 hover:underline font-medium">
-                                ✏️ Редактировать
-                            </a>
+            @if($viewMode === 'cards')
+                <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                    @foreach($skladchinas as $skladchina)
+                        <div class="bg-white dark:bg-gray-800 rounded-2xl shadow hover:shadow-lg transition">
+                            <x-skladchina-card :skladchina="$skladchina" :user="auth()->user()" />
+                            <div class="border-t px-4 py-3 text-center">
+                                <a href="{{ route('skladchinas.edit', $skladchina) }}"
+                                   class="inline-block text-sm text-blue-600 dark:text-blue-400 hover:underline font-medium">
+                                    ✏️ Редактировать
+                                </a>
+                            </div>
                         </div>
-                    </div>
-                @endforeach
-            </div>
+                    @endforeach
+                </div>
+            @else
+                <div class="overflow-x-auto bg-white dark:bg-gray-800 rounded-lg shadow">
+                    <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                        <thead class="bg-gray-50 dark:bg-gray-900">
+                            <tr>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">#</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Название</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Категория</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Взнос</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Сбор</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Статус</th>
+                                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Действия</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                            @foreach($skladchinas as $index => $skladchina)
+                                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $index + 1 }}</td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                                        <a href="{{ route('skladchinas.edit', $skladchina) }}" class="hover:underline">{{ $skladchina->name }}</a>
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{{ optional($skladchina->category)->name ?? '—' }}</td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-blue-600 font-semibold">{{ number_format($skladchina->member_price, 0, '', ' ') }} ₽</td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 font-semibold">{{ number_format($skladchina->full_price, 0, '', ' ') }} ₽</td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                        <span class="inline-block px-2 py-1 text-white bg-green-500 rounded-full text-xs">{{ $skladchina->status_label }}</span>
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                                        <a href="{{ route('skladchinas.edit', $skladchina) }}" class="text-blue-600 dark:text-blue-400 hover:underline">Редактировать</a>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
         @endif
     </div>
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,7 +16,8 @@ Route::get('/dashboard', function () {
     $user = auth()->user();
     $skladchinas = $user?->skladchinas()->with('category')->get() ?? collect();
     $transactions = $user?->transactions()->latest()->take(10)->get() ?? collect();
-    return view('dashboard', compact('skladchinas', 'transactions'));
+    $viewMode = request('view', 'cards');
+    return view('dashboard', compact('skladchinas', 'transactions', 'viewMode'));
 })->middleware(['auth', 'verified'])->name('dashboard');
 
 Route::middleware('auth')->group(function () {


### PR DESCRIPTION
## Summary
- allow organizer and admin user pages to switch between card and table view
- add same toggle for regular dashboard page
- support `view` query parameter in controllers and routes

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841211bf2008328b8aeef3f3430546e