### PR TITLE
Fix admin access date

### DIFF
--- a/app/Models/Skladchina.php
+++ b/app/Models/Skladchina.php
@@ -49,7 +49,7 @@ class Skladchina extends Model
     {
         return $this->belongsToMany(User::class)
             ->withTimestamps()
-            ->withPivot('paid');
+            ->withPivot('paid', 'access_until');
     }
 
     public function images(): HasMany


### PR DESCRIPTION
## Summary
- allow loading `access_until` from pivot to correctly display and save admin access expiration

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68412b6b33048328ac276345ccba8413