### PR TITLE
Add access duration settings

### DIFF
--- a/app/Http/Controllers/Admin/SettingController.php
+++ b/app/Http/Controllers/Admin/SettingController.php
@@ -12,7 +12,8 @@ class SettingController extends Controller
     {
         $percent = Setting::value('organizer_share_percent', 70);
         $discount = Setting::value('repeat_discount_percent', 40);
-        return view('admin.settings.edit', compact('percent', 'discount'));
+        $days = Setting::value('default_access_days', 30);
+        return view('admin.settings.edit', compact('percent', 'discount', 'days'));
     }
 
     public function update(Request $request)
@@ -20,6 +21,7 @@ class SettingController extends Controller
         $data = $request->validate([
             'organizer_share_percent' => 'required|numeric|min:0|max:100',
             'repeat_discount_percent' => 'required|numeric|min:0|max:100',
+            'default_access_days' => 'required|integer|min:0',
         ]);
         Setting::updateOrCreate(
             ['key' => 'organizer_share_percent'],
@@ -28,6 +30,10 @@ class SettingController extends Controller
         Setting::updateOrCreate(
             ['key' => 'repeat_discount_percent'],
             ['value' => $data['repeat_discount_percent']]
+        );
+        Setting::updateOrCreate(
+            ['key' => 'default_access_days'],
+            ['value' => $data['default_access_days']]
         );
         return redirect()->route('admin.settings.edit');
     }

--- a/app/Http/Controllers/SkladchinaController.php
+++ b/app/Http/Controllers/SkladchinaController.php
@@ -161,8 +161,10 @@ class SkladchinaController extends Controller
             $skladchina->organizer->notify(new SkladchinaPaid($skladchina, $user));
         }
 
+        $days = (int) Setting::value('default_access_days', 30);
         $skladchina->participants()->updateExistingPivot($user->id, [
             'paid' => true,
+            'access_until' => $days > 0 ? now()->addDays($days) : null,
         ]);
 
         $skladchina->status = Skladchina::STATUS_AVAILABLE;
@@ -214,8 +216,9 @@ class SkladchinaController extends Controller
             ]);
         }
 
+        $days = (int) Setting::value('default_access_days', 30);
         $skladchina->participants()->updateExistingPivot($user->id, [
-            'access_until' => now()->addDays(30),
+            'access_until' => $days > 0 ? now()->addDays($days) : null,
         ]);
 
         return redirect()->route('skladchinas.show', $skladchina);

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -34,5 +34,9 @@ class DatabaseSeeder extends Seeder
             ['key' => 'repeat_discount_percent'],
             ['value' => '40']
         );
+        \App\Models\Setting::updateOrCreate(
+            ['key' => 'default_access_days'],
+            ['value' => '30']
+        );
     }
 }

--- a/resources/views/admin/settings/edit.blade.php
+++ b/resources/views/admin/settings/edit.blade.php
@@ -12,6 +12,10 @@
             <span class="text-gray-700 dark:text-gray-300">Скидка на повторное участие (%)</span>
             <input type="number" name="repeat_discount_percent" value="{{ $discount }}" class="border rounded p-2 w-full" step="0.01" />
         </label>
+        <label class="block">
+            <span class="text-gray-700 dark:text-gray-300">Количество дней доступа</span>
+            <input type="number" name="default_access_days" value="{{ $days }}" class="border rounded p-2 w-full" />
+        </label>
         <x-primary-button>Сохранить</x-primary-button>
     </form>
 @endsection

--- a/resources/views/skladchinas/show.blade.php
+++ b/resources/views/skladchinas/show.blade.php
@@ -11,6 +11,9 @@
                 foreach ($skladchina->images as $img) {
                     $gallery->push($img->path);
                 }
+                $participant = auth()->check()
+                    ? $skladchina->participants->where('id', auth()->id())->first()
+                    : null;
             @endphp
 
             {{-- ГАЛЕРЕЯ --}}
@@ -79,6 +82,12 @@
                     <span class="inline-block {{ $skladchina->status_badge_classes }} text-sm font-semibold px-3 py-1 rounded-full">
                         {{ $skladchina->status_label }}
                     </span>
+                    @if($participant && $participant->pivot->paid)
+                        <span class="text-sm text-gray-500 dark:text-gray-300">
+                            Доступ до
+                            {{ $participant->pivot->access_until ? \Carbon\Carbon::parse($participant->pivot->access_until)->format('Y-m-d') : '∞' }}
+                        </span>
+                    @endif
                 </div>
 
                 {{-- Название --}}
@@ -106,11 +115,6 @@
 
                 {{-- Участие / Оплата --}}
                 <div class="mb-6">
-                    @php
-                        $participant = auth()->check() 
-                            ? $skladchina->participants->where('id', auth()->id())->first() 
-                            : null;
-                    @endphp
 
                     @if($participant)
                         <div class="flex flex-wrap items-center gap-3">


### PR DESCRIPTION
## Summary
- show access expiration next to skladchina status
- allow admins to configure default access duration in days
- apply access duration when paying or renewing

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68412ebb310483288dbdac46e16b7c5e