### PR TITLE
Add static pages and ignore zips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Homestead.yaml
 npm-debug.log
 Thumbs.db
 yarn-error.log
+*.zip

--- a/resources/views/static/about.blade.php
+++ b/resources/views/static/about.blade.php
@@ -1,0 +1,9 @@
+<x-app-layout>
+    <div class="max-w-7xl mx-auto p-6">
+        <h1 class="text-2xl font-bold mb-4">О проекте</h1>
+        <p class="text-gray-700 dark:text-gray-300">
+            Это демонстрационная страница проекта. Здесь вы можете разместить
+            информацию о целях и возможностях сервиса.
+        </p>
+    </div>
+</x-app-layout>

--- a/resources/views/static/contacts.blade.php
+++ b/resources/views/static/contacts.blade.php
@@ -1,0 +1,8 @@
+<x-app-layout>
+    <div class="max-w-7xl mx-auto p-6">
+        <h1 class="text-2xl font-bold mb-4">Контакты</h1>
+        <p class="text-gray-700 dark:text-gray-300">
+            Здесь можно разместить контактные данные или форму обратной связи.
+        </p>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,8 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/', HomeController::class)->name('home');
 Route::get('sitemap.xml', SitemapController::class)->name('sitemap');
+Route::view('about', 'static.about')->name('about');
+Route::view('contacts', 'static.contacts')->name('contacts');
 
 // Страница со списком всех категорий
 Route::get('categories', [CategoryController::class, 'index'])


### PR DESCRIPTION
## Summary
- add missing routes for `about` and `contacts`
- create basic `about` and `contacts` views
- ignore accidental zip archives

## Testing
- `php -l routes/web.php`
- `php -l resources/views/layouts/app.blade.php`
- `php -l resources/views/static/about.blade.php`
- `php -l resources/views/static/contacts.blade.php`
- `composer test` *(fails: vendor folder missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841b1293424832889c8605909fd169d