### PR TITLE
Restrict categories page to admins

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -37,7 +37,11 @@
                     <nav class="hidden md:flex space-x-6">
                         <x-nav-link :href="route('home')" :active="request()->routeIs('home')">Главная</x-nav-link>
                         <x-nav-link :href="route('skladchinas.index')" :active="request()->routeIs('skladchinas.*')">Каталог</x-nav-link>
-                        <x-nav-link :href="route('categories.index')" :active="request()->routeIs('categories.*')">Категории</x-nav-link>
+                        @auth
+                            @if(in_array(Auth::user()->role, ['admin','moderator'], true))
+                                <x-nav-link :href="route('admin.categories.index')" :active="request()->routeIs('admin.categories.*')">Категории</x-nav-link>
+                            @endif
+                        @endauth
                         <x-nav-link :href="route('about')" :active="request()->routeIs('about')">О проекте</x-nav-link>
                         <x-nav-link :href="route('contacts')" :active="request()->routeIs('contacts')">Контакты</x-nav-link>
                     </nav>
@@ -107,7 +111,11 @@
             <nav id="mobile-menu" class="hidden md:hidden bg-white dark:bg-gray-800">
                 <x-responsive-nav-link :href="route('home')" :active="request()->routeIs('home')">Главная</x-responsive-nav-link>
                 <x-responsive-nav-link :href="route('skladchinas.index')" :active="request()->routeIs('skladchinas.*')">Каталог</x-responsive-nav-link>
-                <x-responsive-nav-link :href="route('categories.index')" :active="request()->routeIs('categories.*')">Категории</x-responsive-nav-link>
+                @auth
+                    @if(in_array(Auth::user()->role, ['admin','moderator'], true))
+                        <x-responsive-nav-link :href="route('admin.categories.index')" :active="request()->routeIs('admin.categories.*')">Категории</x-responsive-nav-link>
+                    @endif
+                @endauth
                 <x-responsive-nav-link :href="route('about')" :active="request()->routeIs('about')">О проекте</x-responsive-nav-link>
                 <x-responsive-nav-link :href="route('contacts')" :active="request()->routeIs('contacts')">Контакты</x-responsive-nav-link>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,10 +16,6 @@ Route::get('sitemap.xml', SitemapController::class)->name('sitemap');
 Route::view('about', 'static.about')->name('about');
 Route::view('contacts', 'static.contacts')->name('contacts');
 
-// Страница со списком всех категорий
-Route::get('categories', [CategoryController::class, 'index'])
-    ->name('categories.index');
-
 // Страница конкретной категории по slug
 Route::get('categories/{category:slug}', [CategoryController::class, 'show'])
     ->name('categories.show');


### PR DESCRIPTION
## Summary
- hide categories index from public routes
- display categories link only for admins/moderators

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841b55dfce8832896b1d6aebca7eeef