### PR TITLE
Add account pages and update navigation

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+class AccountController extends Controller
+{
+    public function balance(): View
+    {
+        return view('account.balance');
+    }
+
+    public function transactions(): View
+    {
+        $transactions = Auth::user()->transactions()->latest()->get();
+        return view('account.transactions', compact('transactions'));
+    }
+
+    public function participations(): View
+    {
+        $user = Auth::user();
+        $viewMode = request('view', 'cards');
+        $skladchinas = $user->skladchinas()->with('category')->get();
+        return view('account.participations', compact('skladchinas', 'viewMode'));
+    }
+}

--- a/resources/views/account/balance.blade.php
+++ b/resources/views/account/balance.blade.php
@@ -1,0 +1,4 @@
+<x-app-layout>
+    <h1 class="text-xl font-bold mb-4">Баланс</h1>
+    <p>Текущий баланс: {{ number_format(Auth::user()->balance, 2) }} ₽</p>
+</x-app-layout>

--- a/resources/views/account/participations.blade.php
+++ b/resources/views/account/participations.blade.php
@@ -1,0 +1,67 @@
+<x-app-layout>
+    <div class="py-6">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <div class="flex items-center justify-between mb-4">
+                    <h3 class="font-bold">Мои складчины</h3>
+                    @php $toggleView = $viewMode === 'cards' ? 'table' : 'cards'; @endphp
+                    <a href="{{ route('account.participations', ['view' => $toggleView]) }}" class="inline-flex items-center px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700">
+                        @if($viewMode === 'cards')
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" viewBox="0 0 20 20" fill="currentColor">
+                                <path d="M3 3h14v2H3V3zm0 4h7v2H3V7zm0 4h14v2H3v-2zm0 4h7v2H3v-2z" />
+                            </svg>
+                            Показать списком
+                        @else
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" viewBox="0 0 20 20" fill="currentColor">
+                                <path d="M4 3h4v4H4V3zm6 0h4v4h-4V3zm-6 6h4v4H4V9zm6 0h4v4h-4V9zm-6 6h4v4H4v-4zm6 6h4v4h-4v-4z" />
+                            </svg>
+                            Показать карточками
+                        @endif
+                    </a>
+                </div>
+
+                @if($viewMode === 'cards')
+                    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+                        @forelse($skladchinas as $item)
+                            <x-skladchina-card :skladchina="$item" />
+                        @empty
+                            <p>Вы пока не участвуете в складчинах.</p>
+                        @endforelse
+                    </div>
+                @else
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-200">
+                            <thead class="bg-gray-50">
+                                <tr>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">#</th>
+                                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Название</th>
+                                    <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Оплачено</th>
+                                    <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Доступ до</th>
+                                </tr>
+                            </thead>
+                            <tbody class="bg-white divide-y divide-gray-200">
+                                @foreach($skladchinas as $index => $item)
+                                    @php $pivot = $item->pivot; @endphp
+                                    <tr>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $index + 1 }}</td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                            <a href="{{ route('skladchinas.show', $item) }}" class="hover:underline">{{ $item->name }}</a>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-center">
+                                            <span class="inline-block px-2 py-1 text-xs rounded-full {{ $pivot->paid ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800' }}">
+                                                {{ $pivot->paid ? 'Оплачено' : 'Не оплачено' }}
+                                            </span>
+                                        </td>
+                                        <td class="px-6 py-4 whitespace-nowrap text-center text-sm text-gray-700">
+                                            {{ $pivot->access_until ? \Carbon\Carbon::parse($pivot->access_until)->format('Y-m-d') : '-' }}
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                @endif
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/account/transactions.blade.php
+++ b/resources/views/account/transactions.blade.php
@@ -1,0 +1,10 @@
+<x-app-layout>
+    <h1 class="text-xl font-bold mb-4">Движение баланса</h1>
+    <ul class="space-y-1">
+        @forelse($transactions as $tr)
+            <li>{{ $tr->created_at->format('d.m H:i') }} - {{ $tr->description }}: {{ number_format($tr->amount, 2) }} ₽</li>
+        @empty
+            <li>Пока нет операций.</li>
+        @endforelse
+    </ul>
+</x-app-layout>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -38,8 +38,17 @@
                         <x-nav-link :href="route('home')" :active="request()->routeIs('home')">Главная</x-nav-link>
                         <x-nav-link :href="route('skladchinas.index')" :active="request()->routeIs('skladchinas.*')">Каталог</x-nav-link>
                         @auth
+                            <x-nav-link :href="route('account.balance')" :active="request()->routeIs('account.balance')">Баланс</x-nav-link>
+                            <x-nav-link :href="route('account.transactions')" :active="request()->routeIs('account.transactions')">Движение баланса</x-nav-link>
+                            <x-nav-link :href="route('account.participations')" :active="request()->routeIs('account.participations')">Мои складчины</x-nav-link>
+                            @if(Auth::user()->role === 'organizer')
+                                <x-nav-link :href="route('organizer.skladchinas.index')" :active="request()->routeIs('organizer.skladchinas.*')">Организуемые складчины</x-nav-link>
+                            @endif
                             @if(in_array(Auth::user()->role, ['admin','moderator'], true))
                                 <x-nav-link :href="route('admin.categories.index')" :active="request()->routeIs('admin.categories.*')">Категории</x-nav-link>
+                            @endif
+                            @if(in_array(Auth::user()->role, ['admin','moderator'], true))
+                                <x-nav-link :href="route('admin.dashboard')" :active="request()->routeIs('admin.*')">Админ</x-nav-link>
                             @endif
                         @endauth
                         <x-nav-link :href="route('about')" :active="request()->routeIs('about')">О проекте</x-nav-link>
@@ -112,8 +121,15 @@
                 <x-responsive-nav-link :href="route('home')" :active="request()->routeIs('home')">Главная</x-responsive-nav-link>
                 <x-responsive-nav-link :href="route('skladchinas.index')" :active="request()->routeIs('skladchinas.*')">Каталог</x-responsive-nav-link>
                 @auth
+                    <x-responsive-nav-link :href="route('account.balance')" :active="request()->routeIs('account.balance')">Баланс</x-responsive-nav-link>
+                    <x-responsive-nav-link :href="route('account.transactions')" :active="request()->routeIs('account.transactions')">Движение баланса</x-responsive-nav-link>
+                    <x-responsive-nav-link :href="route('account.participations')" :active="request()->routeIs('account.participations')">Мои складчины</x-responsive-nav-link>
+                    @if(Auth::user()->role === 'organizer')
+                        <x-responsive-nav-link :href="route('organizer.skladchinas.index')" :active="request()->routeIs('organizer.skladchinas.*')">Организуемые складчины</x-responsive-nav-link>
+                    @endif
                     @if(in_array(Auth::user()->role, ['admin','moderator'], true))
                         <x-responsive-nav-link :href="route('admin.categories.index')" :active="request()->routeIs('admin.categories.*')">Категории</x-responsive-nav-link>
+                        <x-responsive-nav-link :href="route('admin.dashboard')" :active="request()->routeIs('admin.*')">Админ</x-responsive-nav-link>
                     @endif
                 @endauth
                 <x-responsive-nav-link :href="route('about')" :active="request()->routeIs('about')">О проекте</x-responsive-nav-link>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Admin\SettingController;
 use App\Http\Controllers\Admin\SkladchinaImportController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\SitemapController;
+use App\Http\Controllers\AccountController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', HomeController::class)->name('home');
@@ -32,6 +33,10 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    Route::get('/balance', [AccountController::class, 'balance'])->name('account.balance');
+    Route::get('/transactions', [AccountController::class, 'transactions'])->name('account.transactions');
+    Route::get('/my-skladchinas', [AccountController::class, 'participations'])->name('account.participations');
 });
 
 Route::middleware('auth')->post('skladchinas/{skladchina}/join', [SkladchinaController::class, 'join'])->name('skladchinas.join');


### PR DESCRIPTION
## Summary
- add `AccountController` with balance, transactions and participations pages
- display balance, balance history and user sklads
- extend navigation with links to account pages and organizer section
- register new routes

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841b84fb7f083289e4a87f15fda9164