### PR TITLE
Fix watermark default font

### DIFF
--- a/app/Services/ImageService.php
+++ b/app/Services/ImageService.php
@@ -80,7 +80,6 @@ class ImageService
         for ($y = 0; $y <= $height; $y += $yStep) {
             for ($x = 0; $x <= $width; $x += $xStep) {
                 $canvas->text($text, $x, $y, function ($font) use ($fontSize, $angle, $opacity) {
-                    $font->file('/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf');
                     $font->size($fontSize);
                     $font->color('rgba(255,255,255,' . $opacity . ')');
                     $font->angle($angle);


### PR DESCRIPTION
## Summary
- remove custom font specification for watermark so default font is used

## Testing
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fdd5599c8328a367d81b8e507480