### PR TITLE
Fix caching after model updates

### DIFF
--- a/app/Observers/FlushResponseCacheObserver.php
+++ b/app/Observers/FlushResponseCacheObserver.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Observers;
+
+use Spatie\ResponseCache\Facades\ResponseCache;
+
+class FlushResponseCacheObserver
+{
+    public function saved(): void
+    {
+        ResponseCache::clear();
+    }
+
+    public function deleted(): void
+    {
+        ResponseCache::clear();
+    }
+
+    public function restored(): void
+    {
+        ResponseCache::clear();
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,9 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use App\Models\Skladchina;
+use App\Models\User;
+use App\Observers\FlushResponseCacheObserver;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +22,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Skladchina::observe(FlushResponseCacheObserver::class);
+        User::observe(FlushResponseCacheObserver::class);
     }
 }


### PR DESCRIPTION
## Summary
- clear response cache when models change
- observe `Skladchina` and `User` model events to flush caches

## Testing
- `php artisan test` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842020569508328b85bcbbaf0b5c724