### PR TITLE
Move breadcrumbs above product view

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -146,6 +146,14 @@
             </nav>
         </header>
 
+        @hasSection('breadcrumbs')
+            <div class="bg-gray-50 dark:bg-gray-900 shadow-sm">
+                <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2">
+                    @yield('breadcrumbs')
+                </div>
+            </div>
+        @endhasSection
+
         {{-- ====== ПОДШАПОЧНАЯ ПАНЕЛЬ (Sub-header / Panel) ====== --}}
         <div class="bg-gray-50 dark:bg-gray-900 shadow-sm">
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-col md:flex-row md:justify-between md:items-center space-y-4 md:space-y-0">

--- a/resources/views/skladchinas/show.blade.php
+++ b/resources/views/skladchinas/show.blade.php
@@ -1,5 +1,35 @@
 {{-- resources/views/skladchinas/show.blade.php --}}
 @section('title', $skladchina->name . ' | ' . config('app.name'))
+
+@section('breadcrumbs')
+    <nav aria-label="breadcrumb">
+        <ol class="flex flex-wrap items-center text-sm text-gray-600 dark:text-gray-300" itemscope itemtype="https://schema.org/BreadcrumbList">
+            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="flex items-center">
+                <a itemprop="item" href="{{ route('home') }}" class="text-blue-600 hover:underline"><span itemprop="name">Главная</span></a>
+                <meta itemprop="position" content="1" />
+            </li>
+            <li aria-hidden="true" class="mx-2 text-gray-400">&#8250;</li>
+            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="flex items-center">
+                <a itemprop="item" href="{{ route('skladchinas.index') }}" class="text-blue-600 hover:underline"><span itemprop="name">Каталог</span></a>
+                <meta itemprop="position" content="2" />
+            </li>
+            @if($skladchina->category)
+                <li aria-hidden="true" class="mx-2 text-gray-400">&#8250;</li>
+                <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="flex items-center">
+                    <a itemprop="item" href="{{ route('categories.show', $skladchina->category->slug) }}" class="text-blue-600 hover:underline"><span itemprop="name">{{ $skladchina->category->name }}</span></a>
+                    <meta itemprop="position" content="3" />
+                </li>
+            @endif
+            <li aria-hidden="true" class="mx-2 text-gray-400">&#8250;</li>
+            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="flex items-center">
+                <span itemprop="name">{{ $skladchina->name }}</span>
+                <meta itemprop="item" content="{{ url()->current() }}" />
+                <meta itemprop="position" content="{{ $skladchina->category ? 4 : 3 }}" />
+            </li>
+        </ol>
+    </nav>
+@endsection
+
 <x-app-layout>
     <div class="max-w-3xl mx-auto px-4 py-10">
         <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl overflow-hidden">
@@ -70,32 +100,6 @@
                 </script>
             @endpush
 
-            <nav aria-label="Breadcrumb" class="px-6 py-4">
-                <ol class="flex flex-wrap items-center text-sm text-gray-600 dark:text-gray-300" itemscope itemtype="https://schema.org/BreadcrumbList">
-                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="flex items-center">
-                        <a itemprop="item" href="{{ route('home') }}" class="text-blue-600 hover:underline"><span itemprop="name">Главная</span></a>
-                        <meta itemprop="position" content="1" />
-                    </li>
-                    <li aria-hidden="true" class="mx-2 text-gray-400">&#8250;</li>
-                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="flex items-center">
-                        <a itemprop="item" href="{{ route('skladchinas.index') }}" class="text-blue-600 hover:underline"><span itemprop="name">Каталог</span></a>
-                        <meta itemprop="position" content="2" />
-                    </li>
-                    @if($skladchina->category)
-                        <li aria-hidden="true" class="mx-2 text-gray-400">&#8250;</li>
-                        <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="flex items-center">
-                            <a itemprop="item" href="{{ route('categories.show', $skladchina->category->slug) }}" class="text-blue-600 hover:underline"><span itemprop="name">{{ $skladchina->category->name }}</span></a>
-                            <meta itemprop="position" content="3" />
-                        </li>
-                    @endif
-                    <li aria-hidden="true" class="mx-2 text-gray-400">&#8250;</li>
-                    <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="flex items-center">
-                        <span itemprop="name">{{ $skladchina->name }}</span>
-                        <meta itemprop="item" content="{{ url()->current() }}" />
-                        <meta itemprop="position" content="{{ $skladchina->category ? 4 : 3 }}" />
-                    </li>
-                </ol>
-            </nav>
 
             {{-- ГАЛЕРЕЯ --}}
             <div class="w-full" 


### PR DESCRIPTION
## Summary
- extract breadcrumbs section in product page
- show breadcrumbs below top navigation when section is present

## Testing
- `phpunit --version` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844f152cacc8328acbb628dc3caf817