### PR TITLE
Fix breadcrumbs closing directive

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -151,7 +151,7 @@
                     @yield('breadcrumbs')
                 </div>
             </div>
-        @endhasSection
+        @endif
 
         {{-- ====== ПОДШАПОЧНАЯ ПАНЕЛЬ (Sub-header / Panel) ====== --}}
         <div class="bg-gray-50 dark:bg-gray-900 shadow-sm">


### PR DESCRIPTION
## Summary
- close `@hasSection` with `@endif` in `layouts/app`

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844f8c6d46483289ae593e5ccc024aa