### PR TITLE
Improve accessibility and caching

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -23,3 +23,16 @@
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
 </IfModule>
+
+<IfModule mod_expires.c>
+    ExpiresActive On
+    ExpiresByType text/css "access plus 1 year"
+    ExpiresByType application/javascript "access plus 1 year"
+    ExpiresByType image/webp "access plus 1 year"
+</IfModule>
+
+<IfModule mod_headers.c>
+    <FilesMatch "\.(css|js|webp)$">
+        Header set Cache-Control "max-age=31536000, public"
+    </FilesMatch>
+</IfModule>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -10,8 +10,8 @@
     @stack('meta')
 
     <!-- Fonts + Tailwind CSS (через Vite) -->
-    <link rel="preconnect" href="https://fonts.bunny.net">
-    <link rel="preload" as="style" href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" onload="this.rel='stylesheet'">
+    <link rel="preconnect" href="https://fonts.bunny.net" crossorigin>
+    <link rel="preload" as="style" href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" onload="this.rel='stylesheet'" crossorigin>
     <noscript><link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet"></noscript>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
@@ -56,7 +56,7 @@
                     <div class="flex items-center space-x-4">
 
                         {{-- 3.1) Переключатель светлая/тёмная тема --}}
-                        <button id="theme-toggle" type="button"
+                        <button id="theme-toggle" type="button" aria-label="Переключить тему"
                                 class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white focus:outline-none">
                             <svg id="theme-toggle-light-icon" class="hidden w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
                                 <path d="M10 15.172a5.172 5.172 0 110-10.344 5.172 5.172 0 010 10.344zm0-12.172v-2a1 1 0 012 0v2a1 1 0 01-2 0zm0 16v2a1 1 0 102 0v-2a1 1 0 00-2 0zm8.485-10.485l1.414-1.414a1 1 0 00-1.414-1.414L17.071 7.83a1 1 0 001.414 1.414zm-14.97 0a1 1 0 00-1.414-1.414L.1 7.07a1 1 0 101.414 1.414L3.515 7.828zm14.97 7.071l1.414 1.414a1 1 0 001.414-1.414l-1.414-1.414a1 1 0 00-1.414 1.414zM3.515 11.94a1 1 0 011.414 1.414L3.515 14.768a1 1 0 11-1.414-1.414l1.414-1.414zM18 10h2a1 1 0 010 2h-2a1 1 0 010-2zm-16 0H0a1 1 0 010 2h2a1 1 0 010-2z"/>
@@ -102,7 +102,7 @@
                         @endauth
 
                         {{-- 3.3) Бургер для мобильного меню --}}
-                        <button id="mobile-menu-button" type="button"
+                        <button id="mobile-menu-button" type="button" aria-label="Открыть меню"
                                 class="md:hidden text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white focus:outline-none">
                             <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -196,7 +196,7 @@
                         <input type="text" name="search" id="search"
                                class="pl-3 pr-10 py-2 w-full md:w-64 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                                placeholder="Поиск по названию…" />
-                        <button type="submit" class="absolute inset-y-0 right-0 pr-3 flex items-center">
+                        <button type="submit" aria-label="Поиск" class="absolute inset-y-0 right-0 pr-3 flex items-center">
                             <svg class="h-5 w-5 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300"
                                  xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"

--- a/resources/views/skladchinas/show.blade.php
+++ b/resources/views/skladchinas/show.blade.php
@@ -59,6 +59,7 @@
                     $mainImage = $skladchina->image_path ?: ($skladchina->images->first()->path ?? null);
                 @endphp
                 @if($mainImage)
+                    <link rel="preload" as="image" href="{{ url('img/'.$mainImage) }}">
                     <meta property="og:image" content="{{ url('img/'.$mainImage) }}">
                     <meta name="twitter:card" content="summary_large_image">
                     <meta name="twitter:image" content="{{ url('img/'.$mainImage) }}">
@@ -111,6 +112,7 @@
                             :src="'/img/' + img"
                             :alt="'{{ $skladchina->title }} — Фото ' + (i + 1)"
                             :loading="i === 0 ? 'eager' : 'lazy'"
+                            :fetchpriority="i === 0 ? 'high' : 'auto'"
                             class="absolute inset-0 w-full h-full object-cover transition-opacity duration-500"
                             x-transition.opacity
                         >
@@ -121,6 +123,7 @@
                         class="absolute left-3 top-1/2 transform -translate-y-1/2 bg-white/80 dark:bg-gray-800/80 rounded-full p-2 hover:bg-white dark:hover:bg-gray-700 transition"
                         x-show="images.length > 1"
                         x-transition.opacity
+                        aria-label="Предыдущее изображение"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-800 dark:text-gray-200" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
@@ -132,6 +135,7 @@
                         class="absolute right-3 top-1/2 transform -translate-y-1/2 bg-white/80 dark:bg-gray-800/80 rounded-full p-2 hover:bg-white dark:hover:bg-gray-700 transition"
                         x-show="images.length > 1"
                         x-transition.opacity
+                        aria-label="Следующее изображение"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-800 dark:text-gray-200" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
@@ -276,9 +280,9 @@
                 {{-- ОПИСАНИЕ --}}
                 @if($skladchina->description)
                     <div class="relative mb-6">
-                        <div 
+                        <div
                             :class="openDesc ? 'max-h-full overflow-visible' : 'max-h-24 overflow-hidden'"
-                            class="text-gray-700 dark:text-gray-300 leading-relaxed transition-all duration-300"
+                            class="text-gray-700 dark:text-gray-300 leading-relaxed transition-all duration-300 min-h-24"
                         >
                             {!! $skladchina->description !!}
                         </div>


### PR DESCRIPTION
## Summary
- add crossorigin preconnect for fonts
- label icon buttons for accessibility
- preload and prioritize main image
- reserve space for description to limit layout shift
- enable year-long caching for static assets

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845007a0ac48328911afb2dddbaef4d