### PR TITLE
Adjust status filters

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -23,19 +23,30 @@ class AccountController extends Controller
         $user = Auth::user();
         $tab = request('tab', 'participating');
         $viewMode = request('view', 'cards');
+        $status = request('status');
 
-        $participating = $user->skladchinas()->with('category')->get();
+        $participating = $user->skladchinas()
+            ->with('category')
+            ->when($status, fn($q) => $q->where('skladchinas.status', $status))
+            ->get();
 
         $organizing = collect();
         if (in_array($user->role, ['admin', 'moderator', 'organizer'], true)) {
-            $organizing = $user->organizedSkladchinas()->with('category', 'images')->get();
+            $organizing = $user->organizedSkladchinas()
+                ->with('category', 'images')
+                ->when($status, fn($q) => $q->where('status', $status))
+                ->get();
         }
+
+        $statuses = \App\Models\Skladchina::statuses();
 
         return view('account.participations', [
             'tab' => $tab,
             'viewMode' => $viewMode,
             'participating' => $participating,
             'organizing' => $organizing,
+            'statuses' => $statuses,
+            'status' => $status,
         ]);
     }
 }

--- a/app/Http/Controllers/SkladchinaController.php
+++ b/app/Http/Controllers/SkladchinaController.php
@@ -21,12 +21,16 @@ class SkladchinaController extends Controller
      */
     public function index()
     {
-        $skladchinas = Skladchina::with('category', 'organizer', 'images')->paginate();
+        $status = request('status');
+        $skladchinas = Skladchina::with('category', 'organizer', 'images')
+            ->when($status, fn($q) => $q->where('status', $status))
+            ->paginate();
         $isAdmin = request()->routeIs('admin.*');
         $view = $isAdmin ? 'admin.skladchinas.index' : 'skladchinas.index';
         $viewMode = request('view', $isAdmin ? 'table' : 'cards');
+        $statuses = Skladchina::statuses();
 
-        return view($view, compact('skladchinas', 'viewMode'));
+        return view($view, compact('skladchinas', 'viewMode', 'statuses', 'status'));
     }
 
     public function my()

--- a/resources/views/account/participations.blade.php
+++ b/resources/views/account/participations.blade.php
@@ -17,9 +17,21 @@
                     </ul>
                 </div>
 
-                <div class="flex items-center justify-end mb-4">
+                <div class="flex items-center justify-between mb-4">
+                    <form method="GET" action="{{ route('account.participations') }}" class="flex items-center space-x-2">
+                        <select name="status" onchange="this.form.submit()" class="px-3 py-1 border rounded bg-gray-50 text-sm">
+                            <option value="">Все статусы</option>
+                            @foreach($statuses as $value => $label)
+                                <option value="{{ $value }}" @selected($status === $value)>{{ $label }}</option>
+                            @endforeach
+                        </select>
+                        <input type="hidden" name="tab" value="{{ $tab }}" />
+                        <input type="hidden" name="view" value="{{ $viewMode }}" />
+                    </form>
+
                     @php $toggleView = $viewMode === 'cards' ? 'table' : 'cards'; @endphp
-                    <a href="{{ route('account.participations', ['tab' => $tab, 'view' => $toggleView]) }}" class="inline-flex items-center px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700">
+                    <div class="flex items-center space-x-4">
+                        <a href="{{ route('account.participations', ['tab' => $tab, 'view' => $toggleView, 'status' => request('status')]) }}" class="inline-flex items-center px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700">
                         @if($viewMode === 'cards')
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" viewBox="0 0 20 20" fill="currentColor">
                                 <path d="M3 3h14v2H3V3zm0 4h7v2H3V7zm0 4h14v2H3v-2zm0 4h7v2H3v-2z" />
@@ -31,10 +43,11 @@
                             </svg>
                             Показать карточками
                         @endif
-                    </a>
-                    @if($tab === 'organizing' && in_array(auth()->user()->role, ['admin','moderator','organizer'], true))
-                        <a href="{{ route('skladchinas.create') }}" class="ml-4 inline-flex items-center px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700">+ Создать новую</a>
-                    @endif
+                        </a>
+                        @if($tab === 'organizing' && in_array(auth()->user()->role, ['admin','moderator','organizer'], true))
+                            <a href="{{ route('skladchinas.create') }}" class="inline-flex items-center px-3 py-1 bg-blue-600 text-white text-sm rounded hover:bg-blue-700">+ Создать новую</a>
+                        @endif
+                    </div>
                 </div>
 
                 @if($tab === 'organizing' && in_array(auth()->user()->role, ['admin','moderator','organizer'], true))

--- a/resources/views/admin/skladchinas/index.blade.php
+++ b/resources/views/admin/skladchinas/index.blade.php
@@ -2,12 +2,23 @@
 
 @section('content')
     <div class="flex items-center justify-between mb-6 border-b pb-2">
-        <h1 class="text-2xl font-semibold">Складчины</h1>
+        <form method="GET" action="{{ route('admin.skladchinas.index') }}" class="flex items-center space-x-2">
+            <select name="status" onchange="this.form.submit()" class="px-3 py-2 border rounded-lg bg-gray-50 text-gray-900">
+                <option value="">Все статусы</option>
+                @foreach($statuses as $value => $label)
+                    <option value="{{ $value }}" @selected($status === $value)>{{ $label }}</option>
+                @endforeach
+            </select>
+            <input type="hidden" name="view" value="{{ $viewMode }}" />
+        </form>
+
+        <h1 class="text-2xl font-semibold flex-grow text-center">Складчины</h1>
+
         @php
             $toggleView = ($viewMode === 'cards') ? 'table' : 'cards';
         @endphp
         <div class="flex items-center space-x-4">
-            <a href="{{ route('admin.skladchinas.index', ['view' => $toggleView]) }}" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition">
+            <a href="{{ route('admin.skladchinas.index', ['view' => $toggleView, 'status' => request('status')]) }}" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition">
                 @if($viewMode === 'cards')
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor">
                         <path d="M3 3h14v2H3V3zm0 4h7v2H3V7zm0 4h14v2H3v-2zm0 4h7v2H3v-2z" />

--- a/resources/views/categories/show.blade.php
+++ b/resources/views/categories/show.blade.php
@@ -1,7 +1,18 @@
 <x-app-layout>
     <div class="max-w-7xl mx-auto px-4 py-8">
         <div class="flex items-center justify-between mb-6">
-            <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{{ $category->name }}</h1>
+            <form method="GET" action="{{ route('categories.show', $category->slug) }}" class="flex items-center space-x-2">
+                <select name="status" onchange="this.form.submit()" class="px-3 py-2 border rounded-lg bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+                    <option value="">Все статусы</option>
+                    @foreach($statuses as $value => $label)
+                        <option value="{{ $value }}" @selected($status === $value)>{{ $label }}</option>
+                    @endforeach
+                </select>
+                <input type="hidden" name="view" value="{{ $viewMode }}" />
+            </form>
+
+            <h1 class="text-2xl font-bold text-gray-900 dark:text-white flex-grow text-center">{{ $category->name }}</h1>
+
             @php $toggleView = $viewMode === 'cards' ? 'table' : 'cards'; @endphp
             <a href="{{ route('categories.show', ['category' => $category->slug, 'view' => $toggleView, 'status' => request('status')]) }}" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition">
                 @if($viewMode === 'cards')
@@ -17,16 +28,6 @@
                 @endif
             </a>
         </div>
-
-        <form method="GET" action="{{ route('categories.show', $category->slug) }}" class="mb-6 flex items-center space-x-4">
-            <select name="status" onchange="this.form.submit()" class="px-3 py-2 border rounded-lg bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-                <option value="">Все статусы</option>
-                @foreach($statuses as $value => $label)
-                    <option value="{{ $value }}" @selected($status === $value)>{{ $label }}</option>
-                @endforeach
-            </select>
-            <input type="hidden" name="view" value="{{ $viewMode }}" />
-        </form>
 
         @if($viewMode === 'cards')
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -153,23 +153,6 @@
             <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-col md:flex-row md:justify-between md:items-center space-y-4 md:space-y-0">
                 {{-- Слева: фильтр по статусу и кнопка «Создать» --}}
                 <div class="flex items-center space-x-4">
-                    <div class="relative">
-                        <label for="filter-status" class="sr-only">Фильтр по статусу</label>
-                        <select id="filter-status" name="status"
-                                class="block w-full pl-3 pr-8 py-2 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500">
-                            <option value="">Все статусы</option>
-                            <option value="donation">Сбор донатов</option>
-                            <option value="issue">Выдача</option>
-                            <option value="available">Доступно</option>
-                        </select>
-                        <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-500 dark:text-gray-400">
-                            <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
-                                <path fill-rule="evenodd"
-                                      d="M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 011.08 1.04l-4.25 4.25a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z"
-                                      clip-rule="evenodd"/>
-                            </svg>
-                        </div>
-                    </div>
 
                     @auth
                         @if(in_array(Auth::user()->role, ['admin','moderator','organizer'], true))


### PR DESCRIPTION
## Summary
- restrict global status filter and show it on category view, organizer view, and admin page
- add filter controls to account participations, admin skladchinas list, and category show
- pass filter parameters from controllers

## Testing
- `composer test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_684556c5b34c8328a27e6797950dba0a