### PR TITLE
Implement hidden breadcrumbs and SEO metadata

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,9 @@ use Illuminate\Support\ServiceProvider;
 use App\Models\Skladchina;
 use App\Models\User;
 use App\Observers\FlushResponseCacheObserver;
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Str;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -24,5 +27,36 @@ class AppServiceProvider extends ServiceProvider
     {
         Skladchina::observe(FlushResponseCacheObserver::class);
         User::observe(FlushResponseCacheObserver::class);
+
+        View::composer('*', function ($view) {
+            if (Str::startsWith(Request::path(), 'admin')) {
+                return;
+            }
+
+            $segments = Request::segments();
+            $breadcrumbs = [['url' => route('home'), 'label' => 'Главная']];
+
+            $path = '';
+            foreach ($segments as $index => $segment) {
+                $path .= '/' . $segment;
+                $breadcrumbs[] = [
+                    'url' => $index < count($segments) - 1 ? url($path) : null,
+                    'label' => ucfirst(str_replace('-', ' ', $segment)),
+                ];
+            }
+
+            $data = $view->getData();
+            if (isset($data['category'])) {
+                $breadcrumbs[array_key_last($breadcrumbs)]['label'] = $data['category']->name;
+            }
+            if (isset($data['skladchina'])) {
+                $breadcrumbs[array_key_last($breadcrumbs)]['label'] = $data['skladchina']->title;
+            }
+            if (isset($data['pageTitle'])) {
+                $breadcrumbs[array_key_last($breadcrumbs)]['label'] = $data['pageTitle'];
+            }
+
+            $view->with('autoBreadcrumbs', $breadcrumbs);
+        });
     }
 }

--- a/resources/views/categories/show.blade.php
+++ b/resources/views/categories/show.blade.php
@@ -1,3 +1,42 @@
+@section('title', $category->name)
+
+@push('meta')
+    @php
+        use Illuminate\Support\Str;
+        $seoDescription = Str::limit(strip_tags($category->description ?? ''), 160);
+    @endphp
+    <meta name="description" content="{{ $seoDescription }}">
+    <link rel="canonical" href="{{ url()->current() }}">
+    <meta property="og:title" content="{{ $category->name }}">
+    <meta property="og:description" content="{{ $seoDescription }}">
+    <meta property="og:url" content="{{ url()->current() }}">
+    <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{{ $category->name }}">
+    <meta name="twitter:description" content="{{ $seoDescription }}">
+    <script type="application/ld+json">
+        {!! json_encode([
+            '@context' => 'https://schema.org',
+            '@type' => 'CollectionPage',
+            'name' => $category->name,
+            'description' => $seoDescription,
+            'url' => url()->current(),
+        ], JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES) !!}
+    </script>
+@endpush
+
+@php
+    $crumbs = [
+        ['url' => route('home'), 'label' => 'Главная'],
+        ['url' => route('skladchinas.index'), 'label' => 'Каталог'],
+        ['label' => $category->name],
+    ];
+@endphp
+
+@section('breadcrumbs')
+    <x-breadcrumbs :items="$crumbs" />
+@endsection
+
 <x-app-layout>
     <div class="max-w-7xl mx-auto px-4 py-8">
         <div class="flex items-center justify-between mb-6">

--- a/resources/views/components/breadcrumbs.blade.php
+++ b/resources/views/components/breadcrumbs.blade.php
@@ -1,0 +1,24 @@
+@props(['items', 'class' => 'hidden'])
+
+@if(!empty($items))
+<nav aria-label="breadcrumb" class="{{ $class }}">
+    <ol class="flex flex-wrap items-center text-sm" itemscope itemtype="https://schema.org/BreadcrumbList">
+        @foreach($items as $index => $item)
+            @if($index > 0)
+                <li aria-hidden="true" class="mx-2 text-gray-400">&#8250;</li>
+            @endif
+            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="flex items-center">
+                @if(!empty($item['url']))
+                    <a itemprop="item" href="{{ $item['url'] }}" class="text-blue-600 hover:underline">
+                        <span itemprop="name">{{ $item['label'] }}</span>
+                    </a>
+                @else
+                    <span itemprop="name">{{ $item['label'] }}</span>
+                    <meta itemprop="item" content="{{ url()->current() }}" />
+                @endif
+                <meta itemprop="position" content="{{ $index + 1 }}" />
+            </li>
+        @endforeach
+    </ol>
+</nav>
+@endif

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,3 +1,33 @@
+@section('title', config('app.name'))
+
+@push('meta')
+    @php
+        $seoDescription = 'Список категорий и складчин на сайте ' . config('app.name');
+    @endphp
+    <meta name="description" content="{{ $seoDescription }}">
+    <link rel="canonical" href="{{ url()->current() }}">
+    <meta property="og:title" content="{{ config('app.name') }}">
+    <meta property="og:description" content="{{ $seoDescription }}">
+    <meta property="og:url" content="{{ url()->current() }}">
+    <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{{ config('app.name') }}">
+    <meta name="twitter:description" content="{{ $seoDescription }}">
+    <script type="application/ld+json">
+        {!! json_encode([
+            '@context' => 'https://schema.org',
+            '@type' => 'WebPage',
+            'name' => config('app.name'),
+            'description' => $seoDescription,
+            'url' => url()->current(),
+        ], JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES) !!}
+    </script>
+@endpush
+
+@section('breadcrumbs')
+    <x-breadcrumbs :items="[['label' => 'Главная']]" />
+@endsection
+
 <x-app-layout>
     <div class="max-w-7xl mx-auto px-4 py-8">
         {{-- Заголовок --}}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -141,11 +141,9 @@
         </header>
 
         @hasSection('breadcrumbs')
-            <div class="bg-gray-50 dark:bg-gray-900 shadow-sm">
-                <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2">
-                    @yield('breadcrumbs')
-                </div>
-            </div>
+            @yield('breadcrumbs')
+        @elseif(isset($autoBreadcrumbs))
+            <x-breadcrumbs :items="$autoBreadcrumbs" />
         @endif
 
         {{-- ====== ПОДШАПОЧНАЯ ПАНЕЛЬ (Sub-header / Panel) ====== --}}

--- a/resources/views/skladchinas/show.blade.php
+++ b/resources/views/skladchinas/show.blade.php
@@ -2,32 +2,17 @@
 @section('title', $skladchina->title)
 
 @section('breadcrumbs')
-    <nav aria-label="breadcrumb">
-        <ol class="flex flex-wrap items-center text-sm text-gray-600 dark:text-gray-300" itemscope itemtype="https://schema.org/BreadcrumbList">
-            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="flex items-center">
-                <a itemprop="item" href="{{ route('home') }}" class="text-blue-600 hover:underline"><span itemprop="name">Главная</span></a>
-                <meta itemprop="position" content="1" />
-            </li>
-            <li aria-hidden="true" class="mx-2 text-gray-400">&#8250;</li>
-            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="flex items-center">
-                <a itemprop="item" href="{{ route('skladchinas.index') }}" class="text-blue-600 hover:underline"><span itemprop="name">Каталог</span></a>
-                <meta itemprop="position" content="2" />
-            </li>
-            @if($skladchina->category)
-                <li aria-hidden="true" class="mx-2 text-gray-400">&#8250;</li>
-                <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="flex items-center">
-                    <a itemprop="item" href="{{ route('categories.show', $skladchina->category->slug) }}" class="text-blue-600 hover:underline"><span itemprop="name">{{ $skladchina->category->name }}</span></a>
-                    <meta itemprop="position" content="3" />
-                </li>
-            @endif
-            <li aria-hidden="true" class="mx-2 text-gray-400">&#8250;</li>
-            <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem" class="flex items-center">
-                <span itemprop="name">{{ $skladchina->title }}</span>
-                <meta itemprop="item" content="{{ url()->current() }}" />
-                <meta itemprop="position" content="{{ $skladchina->category ? 4 : 3 }}" />
-            </li>
-        </ol>
-    </nav>
+    @php
+        $crumbs = [
+            ['url' => route('home'), 'label' => 'Главная'],
+            ['url' => route('skladchinas.index'), 'label' => 'Каталог'],
+        ];
+        if ($skladchina->category) {
+            $crumbs[] = ['url' => route('categories.show', $skladchina->category->slug), 'label' => $skladchina->category->name];
+        }
+        $crumbs[] = ['label' => $skladchina->title];
+    @endphp
+    <x-breadcrumbs :items="$crumbs" />
 @endsection
 
 <x-app-layout>


### PR DESCRIPTION
## Summary
- share auto-generated breadcrumbs for all non-admin pages
- render breadcrumbs via new component (hidden by default)
- add SEO metadata and breadcrumbs on category and home pages
- adjust skladchina page to use new breadcrumb component

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455a79a89c83288c9d517cfc05e772