### PR TITLE
Add balance top-up system

### DIFF
--- a/app/Http/Controllers/Admin/TopupController.php
+++ b/app/Http/Controllers/Admin/TopupController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Topup;
+use App\Models\Transaction;
+use Illuminate\Http\Request;
+
+class TopupController extends Controller
+{
+    public function index()
+    {
+        $topups = Topup::with('user')->latest()->paginate();
+        return view('admin.topups.index', compact('topups'));
+    }
+
+    public function update(Request $request, Topup $topup)
+    {
+        $data = $request->validate([
+            'status' => 'required|string',
+        ]);
+
+        if ($topup->status !== Topup::STATUS_PAID && $data['status'] === Topup::STATUS_PAID) {
+            $user = $topup->user;
+            $user->balance += $topup->amount;
+            $user->save();
+
+            Transaction::create([
+                'user_id' => $user->id,
+                'amount' => $topup->amount,
+                'description' => 'Пополнение баланса, заказ #' . $topup->id,
+            ]);
+        }
+
+        $topup->status = $data['status'];
+        $topup->save();
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/TopupController.php
+++ b/app/Http/Controllers/TopupController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Topup;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class TopupController extends Controller
+{
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'amount' => 'required|numeric|min:1',
+        ]);
+
+        $topup = Topup::create([
+            'user_id' => Auth::id(),
+            'amount' => $data['amount'],
+            'status' => Topup::STATUS_PENDING,
+        ]);
+
+        return redirect()->route('topups.thanks', $topup);
+    }
+
+    public function thanks(Topup $topup)
+    {
+        if ($topup->user_id !== Auth::id()) {
+            abort(403);
+        }
+        return view('topups.thanks', compact('topup'));
+    }
+}

--- a/app/Models/Topup.php
+++ b/app/Models/Topup.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Topup extends Model
+{
+    const STATUS_PENDING = 'pending';
+    const STATUS_PAID = 'paid';
+    const STATUS_CANCELLED = 'cancelled';
+    const STATUS_REFUNDED = 'refunded';
+
+    protected $fillable = ['user_id', 'amount', 'status'];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,6 +8,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use App\Models\Skladchina;
 use App\Models\Transaction;
+use App\Models\Topup;
 
 class User extends Authenticatable
 {
@@ -68,6 +69,11 @@ class User extends Authenticatable
     public function transactions()
     {
         return $this->hasMany(Transaction::class);
+    }
+
+    public function topups()
+    {
+        return $this->hasMany(Topup::class);
     }
 
     public function isSubscribed(Skladchina $skladchina): bool

--- a/database/migrations/2025_06_05_020000_create_topups_table.php
+++ b/database/migrations/2025_06_05_020000_create_topups_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('topups', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->decimal('amount', 10, 2);
+            $table->string('status')->default('pending');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('topups');
+    }
+};

--- a/resources/views/account/balance.blade.php
+++ b/resources/views/account/balance.blade.php
@@ -3,6 +3,11 @@
         <div>
             <h1 class="text-xl font-bold mb-4">Баланс</h1>
             <p>Текущий баланс: {{ number_format(Auth::user()->balance, 2) }} ₽</p>
+            <form method="POST" action="{{ route('topups.store') }}" class="mt-4 flex items-center space-x-2">
+                @csrf
+                <input type="number" step="0.01" name="amount" class="border rounded p-2 w-32" placeholder="Сумма">
+                <x-primary-button>Пополнить баланс</x-primary-button>
+            </form>
         </div>
 
         <div>

--- a/resources/views/admin/topups/index.blade.php
+++ b/resources/views/admin/topups/index.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.admin')
+
+@section('content')
+    <h1 class="text-2xl font-semibold mb-6 border-b pb-2">Пополнения баланса</h1>
+    <table class="w-full text-sm">
+        <thead>
+            <tr class="border-b">
+                <th class="py-2 text-left">ID</th>
+                <th class="py-2 text-left">Пользователь</th>
+                <th class="py-2 text-left">Сумма</th>
+                <th class="py-2 text-left">Статус</th>
+                <th class="py-2 text-left">Дата</th>
+                <th class="py-2 text-left"></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($topups as $topup)
+                <tr class="border-b">
+                    <td class="py-1">{{ $topup->id }}</td>
+                    <td class="py-1">{{ $topup->user->name }}</td>
+                    <td class="py-1">{{ number_format($topup->amount, 2) }} ₽</td>
+                    <td class="py-1">{{ $topup->status }}</td>
+                    <td class="py-1">{{ $topup->created_at->format('d.m.Y H:i') }}</td>
+                    <td class="py-1">
+                        <form method="POST" action="{{ route('admin.topups.update', $topup) }}" class="flex items-center space-x-2">
+                            @csrf
+                            @method('PATCH')
+                            <select name="status" class="border rounded p-1">
+                                <option value="pending" @selected($topup->status === 'pending')>Не оплачено</option>
+                                <option value="paid" @selected($topup->status === 'paid')>Оплачено</option>
+                                <option value="cancelled" @selected($topup->status === 'cancelled')>Отменено</option>
+                                <option value="refunded" @selected($topup->status === 'refunded')>Возвращено</option>
+                            </select>
+                            <x-primary-button>Сохранить</x-primary-button>
+                        </form>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+    <div class="mt-4">{{ $topups->links() }}</div>
+@endsection

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -19,6 +19,7 @@
                             <a href="{{ route('admin.skladchinas.index') }}" class="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">Складчины</a>
                             <a href="{{ route('admin.categories.index') }}" class="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">Категории</a>
                             <a href="{{ route('admin.users.index') }}" class="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">Пользователи</a>
+                            <a href="{{ route('admin.topups.index') }}" class="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">Пополнения</a>
                             <a href="{{ route('admin.import.index') }}" class="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">Импорт</a>
                             <a href="{{ route('admin.settings.edit') }}" class="text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">Настройки</a>
                         </div>

--- a/resources/views/topups/thanks.blade.php
+++ b/resources/views/topups/thanks.blade.php
@@ -1,0 +1,9 @@
+<x-app-layout>
+    <div class="space-y-6">
+        <h1 class="text-xl font-bold">Пополнение баланса</h1>
+        <p>Заказ №{{ $topup->id }} на сумму {{ number_format($topup->amount, 2) }} ₽ создан.</p>
+        <p>Переведите указанную сумму на карту, указанную ниже. После подтверждения администратором средства поступят на ваш баланс.</p>
+        <p class="font-semibold">Карта для оплаты: <span class="select-all">1234 5678 9012 3456</span></p>
+        <a href="{{ route('account.balance') }}" class="text-blue-500 underline">Вернуться к балансу</a>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,9 @@ Route::middleware('auth')->group(function () {
     Route::get('/balance', [AccountController::class, 'balance'])->name('account.balance');
     Route::get('/transactions', [AccountController::class, 'balance'])->name('account.transactions');
     Route::get('/my-skladchinas', [AccountController::class, 'participations'])->name('account.participations');
+
+    Route::post('/topups', [\App\Http\Controllers\TopupController::class, 'store'])->name('topups.store');
+    Route::get('/topups/{topup}/thanks', [\App\Http\Controllers\TopupController::class, 'thanks'])->name('topups.thanks');
 });
 
 Route::middleware('auth')->post('skladchinas/{skladchina}/join', [SkladchinaController::class, 'join'])->name('skladchinas.join');
@@ -78,6 +81,9 @@ Route::middleware(['auth', 'role:admin,moderator'])->prefix('admin')->name('admi
     Route::resource('users', UserController::class)
         ->except(['show', 'create', 'store'])
         ->middleware('role:admin');
+
+    Route::get('topups', [\App\Http\Controllers\Admin\TopupController::class, 'index'])->name('topups.index');
+    Route::patch('topups/{topup}', [\App\Http\Controllers\Admin\TopupController::class, 'update'])->name('topups.update');
 
     Route::get('settings', [SettingController::class, 'edit'])
         ->name('settings.edit')


### PR DESCRIPTION
## Summary
- implement `Topup` model and migration
- allow users to create top‑up orders from balance page
- admin interface to confirm top‑ups and credit users
- show link to admin top‑ups page
- thank you page for instructions

## Testing
- `composer test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6845654a026483289253477df7688c7c