### PR TITLE
Enable manual theme toggle

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ import forms from '@tailwindcss/forms';
 
 /** @type {import('tailwindcss').Config} */
 export default {
+    darkMode: 'class',
     content: [
         './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
         './storage/framework/views/*.php',


### PR DESCRIPTION
## Summary
- configure Tailwind for class-based dark mode so the theme toggle works

## Testing
- `npm install`
- `npm run build`
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456fc5c6c88328936461ddc0ed8216