### PR TITLE
Improve responsive balance & category views

### DIFF
--- a/resources/views/account/balance.blade.php
+++ b/resources/views/account/balance.blade.php
@@ -1,20 +1,23 @@
 <x-app-layout>
-    <div class="space-y-6">
-        <div>
-            <h1 class="text-xl font-bold mb-4">Баланс</h1>
-            <p>Текущий баланс: {{ number_format(Auth::user()->balance, 2) }} ₽</p>
-            <form method="POST" action="{{ route('topups.store') }}" class="mt-4 flex items-center space-x-2">
+    <div class="max-w-4xl mx-auto px-4 py-8 space-y-8 lg:space-y-0 lg:grid lg:grid-cols-3 lg:gap-8">
+        <div class="lg:col-span-1 bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
+            <h1 class="text-2xl font-bold mb-4 text-center lg:text-left">Баланс</h1>
+            <p class="text-center lg:text-left text-3xl font-semibold text-gray-900 dark:text-white">{{ number_format(Auth::user()->balance, 2) }} ₽</p>
+            <form method="POST" action="{{ route('topups.store') }}" class="mt-6 flex flex-col sm:flex-row sm:items-center sm:space-x-3">
                 @csrf
-                <input type="number" step="0.01" name="amount" class="border rounded p-2 w-32" placeholder="Сумма">
-                <x-primary-button>Пополнить баланс</x-primary-button>
+                <input type="number" step="0.01" name="amount" class="border rounded p-2 w-full sm:w-32 mb-3 sm:mb-0" placeholder="Сумма">
+                <x-primary-button class="w-full sm:w-auto">Пополнить баланс</x-primary-button>
             </form>
         </div>
 
-        <div>
-            <h2 class="text-lg font-semibold mb-4">Движение баланса</h2>
-            <ul class="space-y-1">
+        <div class="lg:col-span-2 bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
+            <h2 class="text-xl font-semibold mb-4">Движение баланса</h2>
+            <ul class="space-y-2 text-sm">
                 @forelse($transactions as $tr)
-                    <li>{{ $tr->created_at->format('d.m H:i') }} - {{ $tr->description }}: {{ number_format($tr->amount, 2) }} ₽</li>
+                    <li class="flex justify-between">
+                        <span>{{ $tr->created_at->format('d.m H:i') }} - {{ $tr->description }}</span>
+                        <span>{{ number_format($tr->amount, 2) }} ₽</span>
+                    </li>
                 @empty
                     <li>Пока нет операций.</li>
                 @endforelse

--- a/resources/views/categories/show.blade.php
+++ b/resources/views/categories/show.blade.php
@@ -39,33 +39,35 @@
 
 <x-app-layout>
     <div class="max-w-7xl mx-auto px-4 py-8">
-        <div class="flex items-center justify-between mb-6">
-            <form method="GET" action="{{ route('categories.show', $category->slug) }}" class="flex items-center space-x-2">
-                <select name="status" onchange="this.form.submit()" class="px-3 py-2 border rounded-lg bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-                    <option value="">Все статусы</option>
-                    @foreach($statuses as $value => $label)
-                        <option value="{{ $value }}" @selected($status === $value)>{{ $label }}</option>
-                    @endforeach
-                </select>
-                <input type="hidden" name="view" value="{{ $viewMode }}" />
-            </form>
+        <div class="flex flex-col space-y-4 sm:space-y-0 sm:flex-row sm:items-center sm:justify-between mb-6">
+            <h1 class="text-2xl font-bold text-gray-900 dark:text-white text-center sm:flex-grow">{{ $category->name }}</h1>
 
-            <h1 class="text-2xl font-bold text-gray-900 dark:text-white flex-grow text-center">{{ $category->name }}</h1>
+            <div class="flex justify-center sm:justify-end items-center space-x-2">
+                @php $toggleView = $viewMode === 'cards' ? 'table' : 'cards'; @endphp
+                <a href="{{ route('categories.show', ['category' => $category->slug, 'view' => $toggleView, 'status' => request('status')]) }}" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition">
+                    @if($viewMode === 'cards')
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor">
+                            <path d="M3 3h14v2H3V3zm0 4h7v2H3V7zm0 4h14v2H3v-2zm0 4h7v2H3v-2z" />
+                        </svg>
+                        Показать таблицей
+                    @else
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor">
+                            <path d="M4 3h4v4H4V3zm6 0h4v4h-4V3zm-6 6h4v4H4V9zm6 0h4v4h-4V9zm-6 6h4v4H4v-4zm6 6h4v4h-4v-4z" />
+                        </svg>
+                        Показать карточками
+                    @endif
+                </a>
 
-            @php $toggleView = $viewMode === 'cards' ? 'table' : 'cards'; @endphp
-            <a href="{{ route('categories.show', ['category' => $category->slug, 'view' => $toggleView, 'status' => request('status')]) }}" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition">
-                @if($viewMode === 'cards')
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor">
-                        <path d="M3 3h14v2H3V3zm0 4h7v2H3V7zm0 4h14v2H3v-2zm0 4h7v2H3v-2z" />
-                    </svg>
-                    Показать таблицей
-                @else
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2" viewBox="0 0 20 20" fill="currentColor">
-                        <path d="M4 3h4v4H4V3zm6 0h4v4h-4V3zm-6 6h4v4H4V9zm6 0h4v4h-4V9zm-6 6h4v4H4v-4zm6 6h4v4h-4v-4z" />
-                    </svg>
-                    Показать карточками
-                @endif
-            </a>
+                <form method="GET" action="{{ route('categories.show', $category->slug) }}" class="flex items-center space-x-2">
+                    <select name="status" onchange="this.form.submit()" class="px-3 py-2 border rounded-lg bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+                        <option value="">Все статусы</option>
+                        @foreach($statuses as $value => $label)
+                            <option value="{{ $value }}" @selected($status === $value)>{{ $label }}</option>
+                        @endforeach
+                    </select>
+                    <input type="hidden" name="view" value="{{ $viewMode }}" />
+                </form>
+            </div>
         </div>
 
         @if($viewMode === 'cards')
@@ -77,7 +79,7 @@
         @else
             <div class="overflow-x-auto bg-white dark:bg-gray-800 rounded-lg shadow">
                 <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
-                    <thead class="bg-gray-50 dark:bg-gray-900">
+                    <thead class="hidden sm:table-header-group bg-gray-50 dark:bg-gray-900">
                         <tr>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">#</th>
                             <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Название</th>
@@ -88,15 +90,28 @@
                     </thead>
                     <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                         @foreach($skladchinas as $index => $skladchina)
-                            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
-                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $index + 1 }}</td>
-                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                            <tr class="block sm:table-row hover:bg-gray-50 dark:hover:bg-gray-700">
+                                <td class="hidden sm:table-cell px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $index + 1 }}</td>
+                                <td class="hidden sm:table-cell px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                                     <a href="{{ route('skladchinas.show', $skladchina) }}" class="hover:underline">{{ $skladchina->name }}</a>
                                 </td>
-                                <td class="px-6 py-4 whitespace-nowrap text-sm text-blue-600">{{ number_format($skladchina->member_price, 0, '', ' ') }} ₽</td>
-                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ number_format($skladchina->full_price, 0, '', ' ') }} ₽</td>
-                                <td class="px-6 py-4 whitespace-nowrap text-sm">
+                                <td class="hidden sm:table-cell px-6 py-4 whitespace-nowrap text-sm text-blue-600">{{ number_format($skladchina->member_price, 0, '', ' ') }} ₽</td>
+                                <td class="hidden sm:table-cell px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ number_format($skladchina->full_price, 0, '', ' ') }} ₽</td>
+                                <td class="hidden sm:table-cell px-6 py-4 whitespace-nowrap text-sm">
                                     <span class="inline-block px-2 py-1 text-xs rounded-full {{ $skladchina->status_badge_classes }}">{{ $skladchina->status_label }}</span>
+                                </td>
+
+                                <td class="sm:hidden px-6 py-4">
+                                    <div class="text-sm font-semibold mb-1">
+                                        <a href="{{ route('skladchinas.show', $skladchina) }}" class="hover:underline break-words">{{ $skladchina->name }}</a>
+                                    </div>
+                                    <div class="flex flex-wrap text-xs text-gray-600 dark:text-gray-300 space-x-2">
+                                        <span><span class="font-medium">Взнос:</span> {{ number_format($skladchina->member_price, 0, '', ' ') }} ₽</span>
+                                        <span><span class="font-medium">Сбор:</span> {{ number_format($skladchina->full_price, 0, '', ' ') }} ₽</span>
+                                        <span class="mt-1">
+                                            <span class="inline-block px-2 py-1 text-xs rounded-full {{ $skladchina->status_badge_classes }}">{{ $skladchina->status_label }}</span>
+                                        </span>
+                                    </div>
                                 </td>
                             </tr>
                         @endforeach

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -65,13 +65,13 @@
 
                         {{-- 3.1) Переключатель светлая/тёмная тема --}}
                         <button id="theme-toggle" type="button" aria-label="Переключить тему"
-                                class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white focus:outline-none">
-                            <svg id="theme-toggle-light-icon" class="w-6 h-6 transition-opacity opacity-100 dark:opacity-0" fill="none" stroke="currentColor" stroke-width="1.5"
+                                class="relative w-8 h-8 flex items-center justify-center text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white focus:outline-none">
+                            <svg id="theme-toggle-light-icon" class="absolute inset-0 w-6 h-6 transition-opacity opacity-100 dark:opacity-0" fill="none" stroke="currentColor" stroke-width="1.5"
                                  viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round"
                                       d="M12 3v1.5M12 19.5V21M4.22 4.22l1.06 1.06M17.72 17.72l1.06 1.06M3 12h1.5M19.5 12H21M4.22 19.78l1.06-1.06M17.72 6.28l1.06-1.06M12 7.5A4.5 4.5 0 1112 16.5a4.5 4.5 0 010-9z"/>
                             </svg>
-                            <svg id="theme-toggle-dark-icon" class="w-6 h-6 transition-opacity opacity-0 dark:opacity-100" fill="none" stroke="currentColor" stroke-width="1.5"
+                            <svg id="theme-toggle-dark-icon" class="absolute inset-0 w-6 h-6 transition-opacity opacity-0 dark:opacity-100" fill="none" stroke="currentColor" stroke-width="1.5"
                                  viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round"
                                       d="M21 12.79A9 9 0 1111.21 3a7 7 0 109.79 9.79z"/>


### PR DESCRIPTION
## Summary
- enhance account balance page layout for mobile and desktop
- keep theme switch button steady when toggling
- adjust category header and table for better mobile view

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845846f29508328afdf0e4796996b5d