### PR TITLE
Improve balance page dark theme and mobile list

### DIFF
--- a/resources/views/account/balance.blade.php
+++ b/resources/views/account/balance.blade.php
@@ -1,5 +1,6 @@
 <x-app-layout>
-    <div class="max-w-4xl mx-auto px-4 py-8 space-y-8 lg:space-y-0 lg:grid lg:grid-cols-3 lg:gap-8">
+    @php use Illuminate\Support\Str; @endphp
+    <div class="max-w-4xl mx-auto px-4 py-8 space-y-8 lg:space-y-0 lg:grid lg:grid-cols-3 lg:gap-8 lg:items-start">
         <div class="lg:col-span-1 bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
             <h1 class="text-2xl font-bold mb-4 text-center lg:text-left">Баланс</h1>
             <p class="text-center lg:text-left text-3xl font-semibold text-gray-900 dark:text-white">{{ number_format(Auth::user()->balance, 2) }} ₽</p>
@@ -12,14 +13,20 @@
 
         <div class="lg:col-span-2 bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
             <h2 class="text-xl font-semibold mb-4">Движение баланса</h2>
-            <ul class="space-y-2 text-sm">
+            <ul class="space-y-4 text-sm">
                 @forelse($transactions as $tr)
-                    <li class="flex justify-between">
-                        <span>{{ $tr->created_at->format('d.m H:i') }} - {{ $tr->description }}</span>
-                        <span>{{ number_format($tr->amount, 2) }} ₽</span>
+                    <li class="p-4 bg-gray-50 dark:bg-gray-900 rounded-lg">
+                        <p class="font-medium text-gray-900 dark:text-gray-100 break-words">{{ $tr->description }}</p>
+                        <div class="mt-1 flex justify-between text-xs text-gray-500 dark:text-gray-400">
+                            <span>{{ $tr->created_at->format('d.m H:i') }}</span>
+                            <span class="font-semibold {{ $tr->amount >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' }}">{{ number_format($tr->amount, 2) }} ₽</span>
+                        </div>
+                        @if(Str::startsWith($tr->description, 'Доход'))
+                            <div class="mt-1 text-xs text-green-600 dark:text-green-400">Вознаграждение</div>
+                        @endif
                     </li>
                 @empty
-                    <li>Пока нет операций.</li>
+                    <li class="text-gray-500 dark:text-gray-300">Пока нет операций.</li>
                 @endforelse
             </ul>
             <div class="mt-4">{{ $transactions->links() }}</div>

--- a/resources/views/categories/show.blade.php
+++ b/resources/views/categories/show.blade.php
@@ -90,7 +90,7 @@
                     </thead>
                     <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                         @foreach($skladchinas as $index => $skladchina)
-                            <tr class="block sm:table-row hover:bg-gray-50 dark:hover:bg-gray-700">
+                            <tr class="block sm:table-row bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700">
                                 <td class="hidden sm:table-cell px-6 py-4 whitespace-nowrap text-sm text-gray-500">{{ $index + 1 }}</td>
                                 <td class="hidden sm:table-cell px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                                     <a href="{{ route('skladchinas.show', $skladchina) }}" class="hover:underline">{{ $skladchina->name }}</a>
@@ -105,10 +105,10 @@
                                     <div class="text-sm font-semibold mb-1">
                                         <a href="{{ route('skladchinas.show', $skladchina) }}" class="hover:underline break-words">{{ $skladchina->name }}</a>
                                     </div>
-                                    <div class="flex flex-wrap text-xs text-gray-600 dark:text-gray-300 space-x-2">
-                                        <span><span class="font-medium">Взнос:</span> {{ number_format($skladchina->member_price, 0, '', ' ') }} ₽</span>
-                                        <span><span class="font-medium">Сбор:</span> {{ number_format($skladchina->full_price, 0, '', ' ') }} ₽</span>
-                                        <span class="mt-1">
+                                    <div class="flex flex-nowrap items-center gap-x-2 text-xs text-gray-600 dark:text-gray-300">
+                                        <span class="whitespace-nowrap"><span class="font-medium">Взнос:</span> {{ number_format($skladchina->member_price, 0, '', ' ') }} ₽</span>
+                                        <span class="whitespace-nowrap"><span class="font-medium">Сбор:</span> {{ number_format($skladchina->full_price, 0, '', ' ') }} ₽</span>
+                                        <span class="whitespace-nowrap">
                                             <span class="inline-block px-2 py-1 text-xs rounded-full {{ $skladchina->status_badge_classes }}">{{ $skladchina->status_label }}</span>
                                         </span>
                                     </div>


### PR DESCRIPTION
## Summary
- tweak mobile list row layout and dark theme
- restyle balance page for mobile, add reward labels

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845894f302c8328a5e9920d918a44b2