### PR TITLE
Implement responsive images with watermark

### DIFF
--- a/app/Http/Controllers/ImageController.php
+++ b/app/Http/Controllers/ImageController.php
@@ -14,7 +14,11 @@ class ImageController extends Controller
             abort(404);
         }
 
-        $cached = ImageService::cachedPath($path);
+        $width = (int) request('w', 600);
+        if ($width <= 0) {
+            $width = 600;
+        }
+        $cached = ImageService::cachedPath($path, $width);
 
         return response()->file($cached, [
             'Content-Type' => 'image/webp',

--- a/resources/views/components/admin-skladchina-card.blade.php
+++ b/resources/views/components/admin-skladchina-card.blade.php
@@ -2,9 +2,19 @@
 <div class="bg-white rounded-2xl shadow hover:shadow-lg overflow-hidden flex flex-col">
     @if($skladchina->image_path)
         <div class="w-full h-48 overflow-hidden relative group">
-            <img src="{{ url('img/'.$skladchina->image_path) }}" alt="{{ $skladchina->name }}" class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105">
+            <img
+                src="{{ url('img/'.$skladchina->image_path) }}?w=600"
+                srcset="{{ url('img/'.$skladchina->image_path) }}?w=300 300w, {{ url('img/'.$skladchina->image_path) }}?w=600 600w"
+                sizes="(max-width: 640px) 300px, 600px"
+                alt="{{ $skladchina->name }}"
+                class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105">
             @if($skladchina->images->first())
-                <img src="{{ url('img/'.$skladchina->images->first()->path) }}" alt="" class="absolute inset-0 w-full h-full object-cover opacity-0 transition-opacity duration-500 group-hover:opacity-100">
+                <img
+                    src="{{ url('img/'.$skladchina->images->first()->path) }}?w=600"
+                    srcset="{{ url('img/'.$skladchina->images->first()->path) }}?w=300 300w, {{ url('img/'.$skladchina->images->first()->path) }}?w=600 600w"
+                    sizes="(max-width: 640px) 300px, 600px"
+                    alt=""
+                    class="absolute inset-0 w-full h-full object-cover opacity-0 transition-opacity duration-500 group-hover:opacity-100">
             @endif
         </div>
     @else

--- a/resources/views/components/category-skladchina-card.blade.php
+++ b/resources/views/components/category-skladchina-card.blade.php
@@ -29,13 +29,17 @@
     @if($skladchina->image_path)
         <div class="w-full h-48 overflow-hidden relative group">
             <img
-                src="{{ url('img/' . $skladchina->image_path) }}"
+                src="{{ url('img/' . $skladchina->image_path) }}?w=600"
+                srcset="{{ url('img/' . $skladchina->image_path) }}?w=300 300w, {{ url('img/' . $skladchina->image_path) }}?w=600 600w"
+                sizes="(max-width: 640px) 300px, 600px"
                 alt="{{ $skladchina->title }}"
                 class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
             >
             @if($skladchina->images->first())
                 <img
-                    src="{{ url('img/'.$skladchina->images->first()->path) }}"
+                    src="{{ url('img/'.$skladchina->images->first()->path) }}?w=600"
+                    srcset="{{ url('img/'.$skladchina->images->first()->path) }}?w=300 300w, {{ url('img/'.$skladchina->images->first()->path) }}?w=600 600w"
+                    sizes="(max-width: 640px) 300px, 600px"
                     alt=""
                     class="absolute inset-0 w-full h-full object-cover opacity-0 transition-opacity duration-500 group-hover:opacity-100"
                 >

--- a/resources/views/components/home-skladchina-card.blade.php
+++ b/resources/views/components/home-skladchina-card.blade.php
@@ -29,13 +29,17 @@
     @if($skladchina->image_path)
         <div class="w-full h-48 overflow-hidden relative group">
             <img
-                src="{{ url('img/' . $skladchina->image_path) }}"
+                src="{{ url('img/' . $skladchina->image_path) }}?w=600"
+                srcset="{{ url('img/' . $skladchina->image_path) }}?w=300 300w, {{ url('img/' . $skladchina->image_path) }}?w=600 600w"
+                sizes="(max-width: 640px) 300px, 600px"
                 alt="{{ $skladchina->title }}"
                 class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
             >
             @if($skladchina->images->first())
                 <img
-                    src="{{ url('img/'.$skladchina->images->first()->path) }}"
+                    src="{{ url('img/'.$skladchina->images->first()->path) }}?w=600"
+                    srcset="{{ url('img/'.$skladchina->images->first()->path) }}?w=300 300w, {{ url('img/'.$skladchina->images->first()->path) }}?w=600 600w"
+                    sizes="(max-width: 640px) 300px, 600px"
                     alt=""
                     class="absolute inset-0 w-full h-full object-cover opacity-0 transition-opacity duration-500 group-hover:opacity-100"
                 >

--- a/resources/views/components/skladchina-card.blade.php
+++ b/resources/views/components/skladchina-card.blade.php
@@ -29,13 +29,17 @@
     @if($skladchina->image_path)
         <div class="w-full h-48 overflow-hidden relative group">
             <img
-                src="{{ url('img/' . $skladchina->image_path) }}"
+                src="{{ url('img/' . $skladchina->image_path) }}?w=600"
+                srcset="{{ url('img/' . $skladchina->image_path) }}?w=300 300w, {{ url('img/' . $skladchina->image_path) }}?w=600 600w"
+                sizes="(max-width: 640px) 300px, 600px"
                 alt="{{ $skladchina->title }}"
                 class="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
             >
             @if($skladchina->images->first())
                 <img
-                    src="{{ url('img/'.$skladchina->images->first()->path) }}"
+                    src="{{ url('img/'.$skladchina->images->first()->path) }}?w=600"
+                    srcset="{{ url('img/'.$skladchina->images->first()->path) }}?w=300 300w, {{ url('img/'.$skladchina->images->first()->path) }}?w=600 600w"
+                    sizes="(max-width: 640px) 300px, 600px"
                     alt=""
                     class="absolute inset-0 w-full h-full object-cover opacity-0 transition-opacity duration-500 group-hover:opacity-100"
                 >

--- a/resources/views/skladchinas/edit.blade.php
+++ b/resources/views/skladchinas/edit.blade.php
@@ -81,7 +81,7 @@
                 <div>
                     <label for="image" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Обложка (изображение)</label>
                     @if($skladchina->image_path)
-                        <img src="{{ url('img/'.$skladchina->image_path) }}" alt="{{ $skladchina->name }}" class="mb-2 w-full h-40 object-cover rounded">
+                        <img src="{{ url('img/'.$skladchina->image_path) }}?w=600" alt="{{ $skladchina->name }}" class="mb-2 w-full h-40 object-cover rounded">
                     @endif
                     <input type="file" name="image" id="image" accept="image/*" class="block w-full text-gray-700 dark:text-gray-300 file:bg-gray-100 dark:file:bg-gray-700 file:border file:border-gray-300 dark:file:border-gray-600 file:rounded-md file:px-4 file:py-2 file:text-sm file:font-medium file:text-gray-900 dark:file:text-gray-100 file:cursor-pointer hover:file:bg-gray-200 dark:hover:file:bg-gray-600" />
                     @error('image')
@@ -95,7 +95,7 @@
                     @if($skladchina->images->count())
                         <div class="flex flex-wrap gap-2 mb-2">
                             @foreach($skladchina->images as $img)
-                                <img src="{{ url('img/'.$img->path) }}" alt="" class="w-20 h-20 object-cover rounded">
+                                <img src="{{ url('img/'.$img->path) }}?w=200" alt="" class="w-20 h-20 object-cover rounded">
                             @endforeach
                         </div>
                     @endif

--- a/resources/views/skladchinas/show.blade.php
+++ b/resources/views/skladchinas/show.blade.php
@@ -94,7 +94,9 @@
                     <template x-for="(img, i) in images" :key="i">
                         <img
                             x-show="index === i"
-                            :src="'/img/' + img"
+                            :src="'/img/' + img + '?w=800'"
+                            :srcset="'/img/' + img + '?w=400 400w, /img/' + img + '?w=800 800w'"
+                            sizes="(max-width: 640px) 400px, 800px"
                             :alt="'{{ $skladchina->title }} — Фото ' + (i + 1)"
                             :loading="i === 0 ? 'eager' : 'lazy'"
                             :fetchpriority="i === 0 ? 'high' : 'auto'"
@@ -133,8 +135,10 @@
                         <div class="shrink-0">
                             <img
                                 @click="index = i"
-                                :src="'/img/' + img"
-                                :alt="'{{ $skladchina->title }} — Фото ' + (i + 1)"
+                                :src="'/img/' + img + '?w=100'"
+                                :srcset="'/img/' + img + '?w=100 100w, /img/' + img + '?w=200 200w'"
+                                sizes="100px"
+                                :alt="'{{ $skladchina->title }} — Фото ' + (i + 1)" 
                                 loading="lazy"
                                 class="w-16 h-16 object-cover rounded-lg cursor-pointer border-2 transition
                                     "


### PR DESCRIPTION
## Summary
- allow custom widths for image caching and uploads
- support width parameter in image controller
- reduce watermark grid spacing
- use responsive `srcset` images across views

## Testing
- `composer test` *(fails: No application encryption key specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846edb0e9808328ad576bbbc80cdf5b