### PR TITLE
Fix image preload & ensure watermark path

### DIFF
--- a/app/Services/ImageService.php
+++ b/app/Services/ImageService.php
@@ -16,10 +16,10 @@ class ImageService
         if (strtolower($file->getClientOriginalExtension()) === 'webp') {
             $original = trim($folder, '/') . '/original_' . Str::random(40) . '.webp';
             Storage::disk('images')->put($original, $content);
+        } else {
+            $original = 'originals/' . trim($folder, '/') . '/' . Str::random(40) . '.' . $file->getClientOriginalExtension();
+            Storage::disk('originals')->put($original, $content);
         }
-=======
-        $original = 'originals/' . trim($folder, '/') . '/' . Str::random(40) . '.' . $file->getClientOriginalExtension();
-        Storage::disk('originals')->put($original, $content);
 
         return static::saveAsWebp($content, $folder, $width);
     }

--- a/resources/views/skladchinas/show.blade.php
+++ b/resources/views/skladchinas/show.blade.php
@@ -46,11 +46,10 @@
                 @if($mainImage)
                     <meta property="og:image" content="{{ url('images/'.$mainImage) }}">
                     <link rel="preload" as="image"
-                          href="{{ url('img/'.$mainImage.'?w=800') }}"
-                          imagesrcset="{{ url('img/'.$mainImage.'?w=400') }} 400w, {{ url('img/'.$mainImage.'?w=800') }} 800w"
+                          href="{{ url('images/'.$mainImage.'?w=800') }}"
+                          imagesrcset="{{ url('images/'.$mainImage.'?w=400') }} 400w, {{ url('images/'.$mainImage.'?w=800') }} 800w"
                           imagesizes="(max-width: 640px) 400px, 800px"
                           fetchpriority="high">
-                    <meta property="og:image" content="{{ url('img/'.$mainImage) }}">
                     <meta name="twitter:card" content="summary_large_image">
                     <meta name="twitter:image" content="{{ url('images/'.$mainImage) }}">
                 @else


### PR DESCRIPTION
## Summary
- fix parse error in `ImageService`
- correct preload path for gallery main image and keep others lazy

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_684706ac0374832888110048abd5aa62