### PR TITLE
Optimize image compression quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,8 @@ The Laravel framework is open-sourced software licensed under the [MIT license](
 ## Image Handling
 
 Watermarked images are stored directly under the public directory and served via the `/images/{path}` route.
+
+Images are encoded in WebP format to reduce size. The 800&nbsp;px desktop
+variant is saved with quality **70**, while mobile and smaller thumbnails use
+quality **60** to further decrease the file weight without a noticeable loss in
+visual fidelity.

--- a/app/Services/ImageService.php
+++ b/app/Services/ImageService.php
@@ -55,7 +55,8 @@ class ImageService
 
             $image = Image::make($disk->get($sourcePath));
             static::processImage($image, $width);
-            $disk->put($cache, (string) $image->encode('webp', 80));
+            $quality = $width === 800 ? 70 : 60;
+            $disk->put($cache, (string) $image->encode('webp', $quality));
         }
 
         return $cache;
@@ -67,7 +68,8 @@ class ImageService
             $image = Image::make($content);
             static::processImage($image, $size);
             $path = $size . '/' . trim($folder, '/') . '/' . $name . '.webp';
-            Storage::disk('images')->put($path, (string) $image->encode('webp', 80));
+            $quality = $size === 800 ? 70 : 60;
+            Storage::disk('images')->put($path, (string) $image->encode('webp', $quality));
         }
     }
 


### PR DESCRIPTION
## Summary
- adjust webp quality logic for generated thumbnails and cached images
- document compression quality strategy in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847170130248328a252b0b18c62fbeb