### PR TITLE
Improve gallery with fade animation

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -250,11 +250,13 @@
                 const nextBtn  = gallery.querySelector('[data-next]');
 
                 const show = (i) => {
-                    pictures[index].classList.add('hidden');
+                    pictures[index].classList.add('opacity-0','pointer-events-none');
+                    pictures[index].classList.remove('opacity-100','pointer-events-auto');
                     thumbs[index]?.classList.remove('border-blue-500','ring-2','ring-blue-300','dark:ring-blue-600');
                     thumbs[index]?.classList.add('border-transparent');
                     index = i;
-                    pictures[index].classList.remove('hidden');
+                    pictures[index].classList.remove('opacity-0','pointer-events-none');
+                    pictures[index].classList.add('opacity-100','pointer-events-auto');
                     thumbs[index]?.classList.remove('border-transparent');
                     thumbs[index]?.classList.add('border-blue-500','ring-2','ring-blue-300','dark:ring-blue-600');
                 };
@@ -270,6 +272,20 @@
                 thumbs.forEach((t, i) => {
                     t.addEventListener('click', () => show(i));
                 });
+
+                let autoplayId;
+                const startAutoplay = () => {
+                    if (pictures.length < 2) return;
+                    autoplayId = setInterval(() => {
+                        show((index + 1) % pictures.length);
+                    }, 5000);
+                };
+                const stopAutoplay = () => clearInterval(autoplayId);
+
+                gallery.addEventListener('mouseenter', stopAutoplay);
+                gallery.addEventListener('mouseleave', startAutoplay);
+
+                startAutoplay();
             });
 
             // 5) Описание

--- a/resources/views/skladchinas/show.blade.php
+++ b/resources/views/skladchinas/show.blade.php
@@ -95,7 +95,7 @@
             <div class="w-full" data-gallery>
                 <div class="relative w-full h-80 sm:h-96 lg:h-[28rem] bg-gray-100 dark:bg-gray-700">
 @foreach($gallery as $i => $img)
-                    <picture class="absolute inset-0 w-full h-full transition-opacity duration-500 {{ $i === 0 ? '' : 'hidden' }}">
+                    <picture class="absolute inset-0 w-full h-full opacity-0 pointer-events-none transition-opacity duration-500 {{ $i === 0 ? 'opacity-100 pointer-events-auto' : '' }}">
                         <source media="(max-width: 640px)" srcset="/images/400/{{ $img }}">
                         <img src="/images/800/{{ $img }}"
                              alt="{{ $skladchina->title }} — Фото {{ $i + 1 }}"


### PR DESCRIPTION
## Summary
- enhance gallery markup to use opacity transitions
- update gallery logic to fade between images and autoplay

## Testing
- `composer test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6847b82e1b288328b04512f465792788