### PR TITLE
Remove gallery navigation arrows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "skladchina",
+    "name": "sklad",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -1189,23 +1189,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
             "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@vue/reactivity": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
-            "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@vue/shared": "3.1.5"
-            }
-        },
-        "node_modules/@vue/shared": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
-            "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
             "dev": true,
             "license": "MIT"
         },

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,11 +1,11 @@
 {
   "resources/css/app.css": {
-    "file": "assets/app-B_SqYsYo.css",
+    "file": "assets/app-R3zZi1nr.css",
     "src": "resources/css/app.css",
     "isEntry": true
   },
   "resources/js/app.js": {
-    "file": "assets/app-Bf4POITK.js",
+    "file": "assets/app-6IEMI_6G.js",
     "name": "app",
     "src": "resources/js/app.js",
     "isEntry": true

--- a/resources/js/gallery.js
+++ b/resources/js/gallery.js
@@ -5,8 +5,6 @@ function initGalleries() {
         var mobileSource = mainImage.parentElement.querySelector('#mainImageSource');
 
         var thumbs  = gallery.querySelectorAll('.thumb');
-        var prevBtn = gallery.querySelector('[data-prev]');
-        var nextBtn = gallery.querySelector('[data-next]');
         var index   = 0;
 
         function show(i) {
@@ -23,21 +21,33 @@ function initGalleries() {
             thumbs[index].classList.add('border-blue-500', 'ring-2', 'ring-blue-300', 'dark:ring-blue-600');
         }
 
-        if (prevBtn) {
-            prevBtn.addEventListener('click', function () {
-                show(index === 0 ? thumbs.length - 1 : index - 1);
-            });
-        }
 
-        if (nextBtn) {
-            nextBtn.addEventListener('click', function () {
-                show(index === thumbs.length - 1 ? 0 : index + 1);
-            });
-        }
 
         Array.prototype.forEach.call(thumbs, function (t, i) {
             t.addEventListener('click', function () { show(i); });
         });
+
+        if (thumbs.length > 1) {
+            var startX = null;
+            mainImage.addEventListener('click', function () {
+                show(index === thumbs.length - 1 ? 0 : index + 1);
+            });
+            mainImage.addEventListener('touchstart', function (e) {
+                startX = e.touches[0].clientX;
+            }, { passive: true });
+            mainImage.addEventListener('touchend', function (e) {
+                if (startX === null) return;
+                var diff = e.changedTouches[0].clientX - startX;
+                if (Math.abs(diff) > 30) {
+                    if (diff > 0) {
+                        show(index === 0 ? thumbs.length - 1 : index - 1);
+                    } else {
+                        show(index === thumbs.length - 1 ? 0 : index + 1);
+                    }
+                }
+                startX = null;
+            });
+        }
     });
 }
 document.addEventListener('DOMContentLoaded', initGalleries);

--- a/resources/views/skladchinas/show.blade.php
+++ b/resources/views/skladchinas/show.blade.php
@@ -99,7 +99,7 @@
             {{-- ГАЛЕРЕЯ --}}
             <div class="w-full" data-gallery>
                 @if($gallery->first())
-                    <div class="relative bg-gray-100 dark:bg-gray-700 h-80 sm:h-96 lg:h-[28rem] overflow-hidden">
+                    <div class="relative bg-gray-100 dark:bg-gray-700 h-80 sm:h-96 lg:h-[28rem] overflow-hidden cursor-pointer select-none">
                         <picture>
                             <source id="mainImageSource" type="image/avif" media="(max-width: 640px)" srcset="/images/400/{{ str_replace('.webp', '.avif', $gallery->first()) }}">
                             <source type="image/avif" srcset="/images/800/{{ str_replace('.webp', '.avif', $gallery->first()) }}">
@@ -113,16 +113,7 @@
                         </picture>
 
                         @if($gallery->count() > 1)
-                            <button type="button" data-prev class="absolute left-2 top-1/2 -translate-y-1/2 bg-white/70 hover:bg-white text-gray-700 dark:text-gray-800 rounded-full p-2">
-                                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" viewBox="0 0 20 20" fill="currentColor">
-                                    <path fill-rule="evenodd" d="M12.707 15.707a1 1 0 01-1.414 0l-5-5a1 1 0 010-1.414l5-5a1 1 0 011.414 1.414L8.414 10l4.293 4.293a1 1 0 010 1.414z" clip-rule="evenodd" />
-                                </svg>
-                            </button>
-                            <button type="button" data-next class="absolute right-2 top-1/2 -translate-y-1/2 bg-white/70 hover:bg-white text-gray-700 dark:text-gray-800 rounded-full p-2">
-                                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" viewBox="0 0 20 20" fill="currentColor">
-                                    <path fill-rule="evenodd" d="M7.293 4.293a1 1 0 011.414 0L13.707 9.293a1 1 0 010 1.414L8.707 15.707a1 1 0 01-1.414-1.414L11.586 10 7.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" />
-                                </svg>
-                            </button>
+                            {{-- Navigation handled via touch or click on the image --}}
                         @endif
                     </div>
                 @endif


### PR DESCRIPTION
## Summary
- enable clicking or swiping on gallery images for navigation
- remove left/right arrow buttons from the skladchina gallery
- rebuild assets

## Testing
- `npm install`
- `npm run build`
- ❌ `composer test` *(fails: composer/php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684802dea9788328966ffc9d5a3f92e3