### PR TITLE
Optimize mobile image delivery

### DIFF
--- a/resources/views/components/admin-skladchina-card.blade.php
+++ b/resources/views/components/admin-skladchina-card.blade.php
@@ -24,6 +24,8 @@
                 <source type="image/webp" srcset="{{ asset('images/800/'.$skladchina->image_path) }}">
                 <img
                     src="{{ asset('images/800/'.$skladchina->image_path) }}"
+                    srcset="{{ asset('images/400/'.$skladchina->image_path) }} 400w, {{ asset('images/800/'.$skladchina->image_path) }} 800w"
+                    sizes="(max-width: 640px) 400px, 800px"
                     alt="{{ $skladchina->name }}"
                     loading="{{ $preload ? 'eager' : 'lazy' }}"
                     fetchpriority="{{ $preload ? 'high' : 'auto' }}"
@@ -38,6 +40,8 @@
                     <source type="image/webp" srcset="{{ asset('images/800/'.$skladchina->images->first()->path) }}">
                     <img
                         src="{{ asset('images/800/'.$skladchina->images->first()->path) }}"
+                        srcset="{{ asset('images/400/'.$skladchina->images->first()->path) }} 400w, {{ asset('images/800/'.$skladchina->images->first()->path) }} 800w"
+                        sizes="(max-width: 640px) 400px, 800px"
                         alt=""
                         loading="lazy"
                         width="800" height="450"

--- a/resources/views/components/category-skladchina-card.blade.php
+++ b/resources/views/components/category-skladchina-card.blade.php
@@ -50,6 +50,8 @@
                 <source type="image/webp" srcset="{{ asset('images/800/'.$skladchina->image_path) }}">
                 <img
                     src="{{ asset('images/800/'.$skladchina->image_path) }}"
+                    srcset="{{ asset('images/400/'.$skladchina->image_path) }} 400w, {{ asset('images/800/'.$skladchina->image_path) }} 800w"
+                    sizes="(max-width: 640px) 400px, 800px"
                     alt="{{ $skladchina->title }}"
                     loading="{{ $preload ? 'eager' : 'lazy' }}"
                     fetchpriority="{{ $preload ? 'high' : 'auto' }}"
@@ -65,6 +67,8 @@
                     <source type="image/webp" srcset="{{ asset('images/800/'.$skladchina->images->first()->path) }}">
                     <img
                         src="{{ asset('images/800/'.$skladchina->images->first()->path) }}"
+                        srcset="{{ asset('images/400/'.$skladchina->images->first()->path) }} 400w, {{ asset('images/800/'.$skladchina->images->first()->path) }} 800w"
+                        sizes="(max-width: 640px) 400px, 800px"
                         alt=""
                         loading="lazy"
                         width="800" height="450"

--- a/resources/views/components/home-skladchina-card.blade.php
+++ b/resources/views/components/home-skladchina-card.blade.php
@@ -50,6 +50,8 @@
                 <source type="image/webp" srcset="{{ asset('images/800/'.$skladchina->image_path) }}">
                 <img
                     src="{{ asset('images/800/'.$skladchina->image_path) }}"
+                    srcset="{{ asset('images/400/'.$skladchina->image_path) }} 400w, {{ asset('images/800/'.$skladchina->image_path) }} 800w"
+                    sizes="(max-width: 640px) 400px, 800px"
                     alt="{{ $skladchina->title }}"
                     loading="{{ $preload ? 'eager' : 'lazy' }}"
                     fetchpriority="{{ $preload ? 'high' : 'auto' }}"
@@ -65,6 +67,8 @@
                     <source type="image/webp" srcset="{{ asset('images/800/'.$skladchina->images->first()->path) }}">
                     <img
                         src="{{ asset('images/800/'.$skladchina->images->first()->path) }}"
+                        srcset="{{ asset('images/400/'.$skladchina->images->first()->path) }} 400w, {{ asset('images/800/'.$skladchina->images->first()->path) }} 800w"
+                        sizes="(max-width: 640px) 400px, 800px"
                         alt=""
                         loading="lazy"
                         width="800" height="450"

--- a/resources/views/components/skladchina-card.blade.php
+++ b/resources/views/components/skladchina-card.blade.php
@@ -50,6 +50,8 @@
                 <source type="image/webp" srcset="{{ asset('images/800/'.$skladchina->image_path) }}">
                 <img
                     src="{{ asset('images/800/'.$skladchina->image_path) }}"
+                    srcset="{{ asset('images/400/'.$skladchina->image_path) }} 400w, {{ asset('images/800/'.$skladchina->image_path) }} 800w"
+                    sizes="(max-width: 640px) 400px, 800px"
                     alt="{{ $skladchina->title }}"
                     loading="{{ $preload ? 'eager' : 'lazy' }}"
                     fetchpriority="{{ $preload ? 'high' : 'auto' }}"
@@ -65,6 +67,8 @@
                     <source type="image/webp" srcset="{{ asset('images/800/'.$skladchina->images->first()->path) }}">
                     <img
                         src="{{ asset('images/800/'.$skladchina->images->first()->path) }}"
+                        srcset="{{ asset('images/400/'.$skladchina->images->first()->path) }} 400w, {{ asset('images/800/'.$skladchina->images->first()->path) }} 800w"
+                        sizes="(max-width: 640px) 400px, 800px"
                         alt=""
                         loading="lazy"
                         width="800" height="450"

--- a/resources/views/skladchinas/edit.blade.php
+++ b/resources/views/skladchinas/edit.blade.php
@@ -81,7 +81,12 @@
                 <div>
                     <label for="image" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Обложка (изображение)</label>
                     @if($skladchina->image_path)
-                        <img src="{{ asset('images/800/'.$skladchina->image_path) }}" alt="{{ $skladchina->name }}" class="mb-2 w-full h-40 object-cover rounded" width="800" height="450">
+                        <img src="{{ asset('images/800/'.$skladchina->image_path) }}"
+                             srcset="{{ asset('images/400/'.$skladchina->image_path) }} 400w, {{ asset('images/800/'.$skladchina->image_path) }} 800w"
+                             sizes="(max-width: 640px) 400px, 800px"
+                             alt="{{ $skladchina->name }}"
+                             class="mb-2 w-full h-40 object-cover rounded"
+                             width="800" height="450">
                     @endif
                     <input type="file" name="image" id="image" accept="image/*" class="block w-full text-gray-700 dark:text-gray-300 file:bg-gray-100 dark:file:bg-gray-700 file:border file:border-gray-300 dark:file:border-gray-600 file:rounded-md file:px-4 file:py-2 file:text-sm file:font-medium file:text-gray-900 dark:file:text-gray-100 file:cursor-pointer hover:file:bg-gray-200 dark:hover:file:bg-gray-600" />
                     @error('image')

--- a/resources/views/skladchinas/show.blade.php
+++ b/resources/views/skladchinas/show.blade.php
@@ -106,6 +106,8 @@
                             <source type="image/webp" media="(max-width: 640px)" srcset="/images/400/{{ $gallery->first() }}">
                             <source type="image/webp" srcset="/images/800/{{ $gallery->first() }}">
                             <img id="mainImage" src="/images/800/{{ $gallery->first() }}"
+                                 srcset="/images/400/{{ $gallery->first() }} 400w, /images/800/{{ $gallery->first() }} 800w"
+                                 sizes="(max-width: 640px) 400px, 800px"
                                  alt="{{ $skladchina->title }} — Фото 1"
                                  loading="eager" fetchpriority="high"
                                  width="800" height="450"


### PR DESCRIPTION
## Summary
- use `srcset` and `sizes` so mobile devices request 400px images
- apply the change in all card components, the main gallery view and edit form

## Testing
- `./vendor/bin/phpunit --exclude-group broken -c phpunit.xml` *(fails: command not found)*
- `composer test` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848070521e88328875910883f0f704d