### PR TITLE
Fix homepage and participant handling when database empty

### DIFF
--- a/app/Http/Controllers/SkladchinaController.php
+++ b/app/Http/Controllers/SkladchinaController.php
@@ -164,7 +164,7 @@ class SkladchinaController extends Controller
             return redirect()->route('login');
         }
 
-        $pivot = $skladchina->participants()->where('user_id', $user->id)->first()->pivot ?? null;
+        $pivot = $skladchina->participants()->where('user_id', $user->id)->first()?->pivot;
         if (! $pivot || $pivot->paid) {
             return redirect()->route('skladchinas.show', $skladchina);
         }
@@ -224,7 +224,7 @@ class SkladchinaController extends Controller
             return redirect()->route('login');
         }
 
-        $pivot = $skladchina->participants()->where('user_id', $user->id)->first()->pivot ?? null;
+        $pivot = $skladchina->participants()->where('user_id', $user->id)->first()?->pivot;
         if (! $pivot || ! $pivot->paid || ! $pivot->access_until || now()->lte($pivot->access_until)) {
             return redirect()->route('skladchinas.show', $skladchina);
         }
@@ -355,7 +355,7 @@ class SkladchinaController extends Controller
      */
     public function togglePaid(Skladchina $skladchina, User $user)
     {
-        $current = (bool) $skladchina->participants()->where('user_id', $user->id)->first()->pivot->paid;
+        $current = (bool) ($skladchina->participants()->where('user_id', $user->id)->first()?->pivot->paid);
         $skladchina->participants()->updateExistingPivot($user->id, ['paid' => ! $current]);
 
         return back();

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -3,7 +3,7 @@
 @push('meta')
     @php
         $seoDescription = 'Список категорий и складчин на сайте ' . config('app.name');
-        $firstImage = optional(optional($categories->first())->skladchinas->first())->image_path;
+        $firstImage = optional($categories->first()?->skladchinas?->first())->image_path;
     @endphp
     <meta name="description" content="{{ $seoDescription }}">
     <link rel="canonical" href="{{ url()->current() }}">


### PR DESCRIPTION
## Summary
- handle missing categories when picking first image
- avoid null errors when looking up participation pivots

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684846422aa88328bbdc8ecc2f3cf1d3