### PR TITLE
Serve explicit 600px variant for retina devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The Laravel framework is open-sourced software licensed under the [MIT license](
 Watermarked images are stored under the `public/images/{size}` directories and
 served via the `/images/{path}` route.
 
-Images are generated in five resolutions: **100**, **200**, **300**, **800** and
-**1600** pixels. Desktop variants (800 and 1600) are encoded with quality
+Images are generated in six resolutions: **100**, **200**, **300**, **600**,
+**800** and **1600** pixels. Desktop variants (800 and 1600) are encoded with quality
 **60**, while the smaller ones use quality **50**. Every size is saved in both
 AVIF and WebP formats.

--- a/app/Services/ImageService.php
+++ b/app/Services/ImageService.php
@@ -9,7 +9,7 @@ use Intervention\Image\ImageManagerStatic as Image;
 
 class ImageService
 {
-    public const SIZES = [100, 200, 300, 800, 1600];
+    public const SIZES = [100, 200, 300, 600, 800, 1600];
 
     /**
      * Save uploaded file and generate watermarked thumbnails in AVIF and WEBP.
@@ -138,13 +138,15 @@ class ImageService
     {
         $sizes = '(max-width: 640px) 300px, 800px';
         $avifDesktop = asset('images/800/' . str_replace('.webp', '.avif', $path));
+        $avifRetina = asset('images/600/' . str_replace('.webp', '.avif', $path));
         $avifMobile = asset('images/300/' . str_replace('.webp', '.avif', $path));
         $webpDesktop = asset('images/800/' . $path);
+        $webpRetina = asset('images/600/' . $path);
         $webpMobile = asset('images/300/' . $path);
 
         return [
-            "<{$avifDesktop}>; rel=preload; as=image; imagesrcset=\"{$avifMobile} 300w, {$avifDesktop} 800w\"; imagesizes=\"{$sizes}\"",
-            "<{$webpDesktop}>; rel=preload; as=image; imagesrcset=\"{$webpMobile} 300w, {$webpDesktop} 800w\"; imagesizes=\"{$sizes}\"",
+            "<{$avifDesktop}>; rel=preload; as=image; imagesrcset=\"{$avifMobile} 300w, {$avifRetina} 600w, {$avifDesktop} 800w\"; imagesizes=\"{$sizes}\"",
+            "<{$webpDesktop}>; rel=preload; as=image; imagesrcset=\"{$webpMobile} 300w, {$webpRetina} 600w, {$webpDesktop} 800w\"; imagesizes=\"{$sizes}\"",
         ];
     }
 }

--- a/resources/views/components/admin-skladchina-card.blade.php
+++ b/resources/views/components/admin-skladchina-card.blade.php
@@ -3,13 +3,13 @@
     @if($skladchina->image_path)
         <div class="w-full h-48 overflow-hidden relative group">
             <picture>
-                <source type="image/avif" media="(max-width: 640px)" srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $skladchina->image_path)) }}">
+                <source type="image/avif" media="(max-width: 640px)" srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $skladchina->image_path)) }} 300w, {{ asset('images/600/'.str_replace('.webp', '.avif', $skladchina->image_path)) }} 600w">
                 <source type="image/avif" srcset="{{ asset('images/800/'.str_replace('.webp', '.avif', $skladchina->image_path)) }}">
-                <source type="image/webp" media="(max-width: 640px)" srcset="{{ asset('images/300/'.$skladchina->image_path) }}">
+                <source type="image/webp" media="(max-width: 640px)" srcset="{{ asset('images/300/'.$skladchina->image_path) }} 300w, {{ asset('images/600/'.$skladchina->image_path) }} 600w">
                 <source type="image/webp" srcset="{{ asset('images/800/'.$skladchina->image_path) }}">
                 <img
                     src="{{ asset('images/800/'.$skladchina->image_path) }}"
-                    srcset="{{ asset('images/300/'.$skladchina->image_path) }} 300w, {{ asset('images/800/'.$skladchina->image_path) }} 800w"
+                    srcset="{{ asset('images/300/'.$skladchina->image_path) }} 300w, {{ asset('images/600/'.$skladchina->image_path) }} 600w, {{ asset('images/800/'.$skladchina->image_path) }} 800w"
                     sizes="(max-width: 640px) 300px, 800px"
                     alt="{{ $skladchina->name }}"
                     loading="{{ $preload ? 'eager' : 'lazy' }}"
@@ -19,13 +19,13 @@
             </picture>
             @if($skladchina->images->first())
                 <picture class="absolute inset-0 w-full h-full opacity-0 transition-opacity duration-500 group-hover:opacity-100">
-                    <source type="image/avif" media="(max-width: 640px)" srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $skladchina->images->first()->path)) }}">
+                    <source type="image/avif" media="(max-width: 640px)" srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $skladchina->images->first()->path)) }} 300w, {{ asset('images/600/'.str_replace('.webp', '.avif', $skladchina->images->first()->path)) }} 600w">
                     <source type="image/avif" srcset="{{ asset('images/800/'.str_replace('.webp', '.avif', $skladchina->images->first()->path)) }}">
-                    <source type="image/webp" media="(max-width: 640px)" srcset="{{ asset('images/300/'.$skladchina->images->first()->path) }}">
+                    <source type="image/webp" media="(max-width: 640px)" srcset="{{ asset('images/300/'.$skladchina->images->first()->path) }} 300w, {{ asset('images/600/'.$skladchina->images->first()->path) }} 600w">
                     <source type="image/webp" srcset="{{ asset('images/800/'.$skladchina->images->first()->path) }}">
                     <img
                         src="{{ asset('images/800/'.$skladchina->images->first()->path) }}"
-                        srcset="{{ asset('images/300/'.$skladchina->images->first()->path) }} 300w, {{ asset('images/800/'.$skladchina->images->first()->path) }} 800w"
+                        srcset="{{ asset('images/300/'.$skladchina->images->first()->path) }} 300w, {{ asset('images/600/'.$skladchina->images->first()->path) }} 600w, {{ asset('images/800/'.$skladchina->images->first()->path) }} 800w"
                         sizes="(max-width: 640px) 300px, 800px"
                         alt=""
                         loading="lazy"

--- a/resources/views/components/category-skladchina-card.blade.php
+++ b/resources/views/components/category-skladchina-card.blade.php
@@ -29,13 +29,13 @@
     @if($skladchina->image_path)
         <div class="w-full h-48 overflow-hidden relative group">
             <picture>
-                <source type="image/avif" media="(max-width: 640px)" srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $skladchina->image_path)) }}">
+                <source type="image/avif" media="(max-width: 640px)" srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $skladchina->image_path)) }} 300w, {{ asset('images/600/'.str_replace('.webp', '.avif', $skladchina->image_path)) }} 600w">
                 <source type="image/avif" srcset="{{ asset('images/800/'.str_replace('.webp', '.avif', $skladchina->image_path)) }}">
-                <source type="image/webp" media="(max-width: 640px)" srcset="{{ asset('images/300/'.$skladchina->image_path) }}">
+                <source type="image/webp" media="(max-width: 640px)" srcset="{{ asset('images/300/'.$skladchina->image_path) }} 300w, {{ asset('images/600/'.$skladchina->image_path) }} 600w">
                 <source type="image/webp" srcset="{{ asset('images/800/'.$skladchina->image_path) }}">
                 <img
                     src="{{ asset('images/800/'.$skladchina->image_path) }}"
-                    srcset="{{ asset('images/300/'.$skladchina->image_path) }} 300w, {{ asset('images/800/'.$skladchina->image_path) }} 800w"
+                    srcset="{{ asset('images/300/'.$skladchina->image_path) }} 300w, {{ asset('images/600/'.$skladchina->image_path) }} 600w, {{ asset('images/800/'.$skladchina->image_path) }} 800w"
                     sizes="(max-width: 640px) 300px, 800px"
                     alt="{{ $skladchina->title }}"
                     loading="{{ $preload ? 'eager' : 'lazy' }}"
@@ -46,13 +46,13 @@
             </picture>
             @if($skladchina->images->first())
                 <picture class="absolute inset-0 w-full h-full opacity-0 transition-opacity duration-500 group-hover:opacity-100">
-                    <source type="image/avif" media="(max-width: 640px)" srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $skladchina->images->first()->path)) }}">
+                    <source type="image/avif" media="(max-width: 640px)" srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $skladchina->images->first()->path)) }} 300w, {{ asset('images/600/'.str_replace('.webp', '.avif', $skladchina->images->first()->path)) }} 600w">
                     <source type="image/avif" srcset="{{ asset('images/800/'.str_replace('.webp', '.avif', $skladchina->images->first()->path)) }}">
-                    <source type="image/webp" media="(max-width: 640px)" srcset="{{ asset('images/300/'.$skladchina->images->first()->path) }}">
+                    <source type="image/webp" media="(max-width: 640px)" srcset="{{ asset('images/300/'.$skladchina->images->first()->path) }} 300w, {{ asset('images/600/'.$skladchina->images->first()->path) }} 600w">
                     <source type="image/webp" srcset="{{ asset('images/800/'.$skladchina->images->first()->path) }}">
                     <img
                         src="{{ asset('images/800/'.$skladchina->images->first()->path) }}"
-                        srcset="{{ asset('images/300/'.$skladchina->images->first()->path) }} 300w, {{ asset('images/800/'.$skladchina->images->first()->path) }} 800w"
+                        srcset="{{ asset('images/300/'.$skladchina->images->first()->path) }} 300w, {{ asset('images/600/'.$skladchina->images->first()->path) }} 600w, {{ asset('images/800/'.$skladchina->images->first()->path) }} 800w"
                         sizes="(max-width: 640px) 300px, 800px"
                         alt=""
                         loading="lazy"

--- a/resources/views/components/gallery-image.blade.php
+++ b/resources/views/components/gallery-image.blade.php
@@ -10,11 +10,11 @@
          x-transition.opacity
          class="absolute inset-0 w-full h-full object-cover transition-opacity duration-500">
     <source @if($mobileId) id="{{ $mobileId }}" @endif
-      srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $src)) }} 300w, {{ asset('images/800/'.str_replace('.webp', '.avif', $src)) }} 800w, {{ asset('images/1600/'.str_replace('.webp', '.avif', $src)) }} 1600w"
+      srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $src)) }} 300w, {{ asset('images/600/'.str_replace('.webp', '.avif', $src)) }} 600w, {{ asset('images/800/'.str_replace('.webp', '.avif', $src)) }} 800w, {{ asset('images/1600/'.str_replace('.webp', '.avif', $src)) }} 1600w"
       sizes="(max-width:768px) 100vw, 800px"
       type="image/avif">
     <source
-      srcset="{{ asset('images/300/'.$src) }} 300w, {{ asset('images/800/'.$src) }} 800w, {{ asset('images/1600/'.$src) }} 1600w"
+      srcset="{{ asset('images/300/'.$src) }} 300w, {{ asset('images/600/'.$src) }} 600w, {{ asset('images/800/'.$src) }} 800w, {{ asset('images/1600/'.$src) }} 1600w"
       sizes="(max-width:768px) 100vw, 800px"
       type="image/webp">
     <img @if($imgId) id="{{ $imgId }}" @endif src="{{ asset('images/800/'.$src) }}"

--- a/resources/views/components/home-skladchina-card.blade.php
+++ b/resources/views/components/home-skladchina-card.blade.php
@@ -29,13 +29,13 @@
     @if($skladchina->image_path)
         <div class="w-full h-48 overflow-hidden relative group">
             <picture>
-                <source type="image/avif" media="(max-width: 640px)" srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $skladchina->image_path)) }}">
+                <source type="image/avif" media="(max-width: 640px)" srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $skladchina->image_path)) }} 300w, {{ asset('images/600/'.str_replace('.webp', '.avif', $skladchina->image_path)) }} 600w">
                 <source type="image/avif" srcset="{{ asset('images/800/'.str_replace('.webp', '.avif', $skladchina->image_path)) }}">
-                <source type="image/webp" media="(max-width: 640px)" srcset="{{ asset('images/300/'.$skladchina->image_path) }}">
+                <source type="image/webp" media="(max-width: 640px)" srcset="{{ asset('images/300/'.$skladchina->image_path) }} 300w, {{ asset('images/600/'.$skladchina->image_path) }} 600w">
                 <source type="image/webp" srcset="{{ asset('images/800/'.$skladchina->image_path) }}">
                 <img
                     src="{{ asset('images/800/'.$skladchina->image_path) }}"
-                    srcset="{{ asset('images/300/'.$skladchina->image_path) }} 300w, {{ asset('images/800/'.$skladchina->image_path) }} 800w"
+                    srcset="{{ asset('images/300/'.$skladchina->image_path) }} 300w, {{ asset('images/600/'.$skladchina->image_path) }} 600w, {{ asset('images/800/'.$skladchina->image_path) }} 800w"
                     sizes="(max-width: 640px) 300px, 800px"
                     alt="{{ $skladchina->title }}"
                     loading="{{ $preload ? 'eager' : 'lazy' }}"
@@ -46,13 +46,13 @@
             </picture>
             @if($skladchina->images->first())
                 <picture class="absolute inset-0 w-full h-full opacity-0 transition-opacity duration-500 group-hover:opacity-100">
-                    <source type="image/avif" media="(max-width: 640px)" srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $skladchina->images->first()->path)) }}">
+                    <source type="image/avif" media="(max-width: 640px)" srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $skladchina->images->first()->path)) }} 300w, {{ asset('images/600/'.str_replace('.webp', '.avif', $skladchina->images->first()->path)) }} 600w">
                     <source type="image/avif" srcset="{{ asset('images/800/'.str_replace('.webp', '.avif', $skladchina->images->first()->path)) }}">
-                    <source type="image/webp" media="(max-width: 640px)" srcset="{{ asset('images/300/'.$skladchina->images->first()->path) }}">
+                    <source type="image/webp" media="(max-width: 640px)" srcset="{{ asset('images/300/'.$skladchina->images->first()->path) }} 300w, {{ asset('images/600/'.$skladchina->images->first()->path) }} 600w">
                     <source type="image/webp" srcset="{{ asset('images/800/'.$skladchina->images->first()->path) }}">
                     <img
                         src="{{ asset('images/800/'.$skladchina->images->first()->path) }}"
-                        srcset="{{ asset('images/300/'.$skladchina->images->first()->path) }} 300w, {{ asset('images/800/'.$skladchina->images->first()->path) }} 800w"
+                        srcset="{{ asset('images/300/'.$skladchina->images->first()->path) }} 300w, {{ asset('images/600/'.$skladchina->images->first()->path) }} 600w, {{ asset('images/800/'.$skladchina->images->first()->path) }} 800w"
                         sizes="(max-width: 640px) 300px, 800px"
                         alt=""
                         loading="lazy"

--- a/resources/views/components/skladchina-card.blade.php
+++ b/resources/views/components/skladchina-card.blade.php
@@ -31,13 +31,13 @@
     @if($skladchina->image_path)
         <div class="w-full h-48 overflow-hidden relative group">
             <picture>
-                <source type="image/avif" media="(max-width: 640px)" srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $skladchina->image_path)) }}">
+                <source type="image/avif" media="(max-width: 640px)" srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $skladchina->image_path)) }} 300w, {{ asset('images/600/'.str_replace('.webp', '.avif', $skladchina->image_path)) }} 600w">
                 <source type="image/avif" srcset="{{ asset('images/800/'.str_replace('.webp', '.avif', $skladchina->image_path)) }}">
-                <source type="image/webp" media="(max-width: 640px)" srcset="{{ asset('images/300/'.$skladchina->image_path) }}">
+                <source type="image/webp" media="(max-width: 640px)" srcset="{{ asset('images/300/'.$skladchina->image_path) }} 300w, {{ asset('images/600/'.$skladchina->image_path) }} 600w">
                 <source type="image/webp" srcset="{{ asset('images/800/'.$skladchina->image_path) }}">
                 <img
                     src="{{ asset('images/800/'.$skladchina->image_path) }}"
-                    srcset="{{ asset('images/300/'.$skladchina->image_path) }} 300w, {{ asset('images/800/'.$skladchina->image_path) }} 800w"
+                    srcset="{{ asset('images/300/'.$skladchina->image_path) }} 300w, {{ asset('images/600/'.$skladchina->image_path) }} 600w, {{ asset('images/800/'.$skladchina->image_path) }} 800w"
                     sizes="(max-width: 640px) 300px, 800px"
                     alt="{{ $skladchina->title }}"
                     loading="{{ $preload ? 'eager' : 'lazy' }}"
@@ -48,13 +48,13 @@
             </picture>
             @if($skladchina->images->first())
                 <picture class="absolute inset-0 w-full h-full opacity-0 transition-opacity duration-500 group-hover:opacity-100">
-                    <source type="image/avif" media="(max-width: 640px)" srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $skladchina->images->first()->path)) }}">
+                    <source type="image/avif" media="(max-width: 640px)" srcset="{{ asset('images/300/'.str_replace('.webp', '.avif', $skladchina->images->first()->path)) }} 300w, {{ asset('images/600/'.str_replace('.webp', '.avif', $skladchina->images->first()->path)) }} 600w">
                     <source type="image/avif" srcset="{{ asset('images/800/'.str_replace('.webp', '.avif', $skladchina->images->first()->path)) }}">
-                    <source type="image/webp" media="(max-width: 640px)" srcset="{{ asset('images/300/'.$skladchina->images->first()->path) }}">
+                    <source type="image/webp" media="(max-width: 640px)" srcset="{{ asset('images/300/'.$skladchina->images->first()->path) }} 300w, {{ asset('images/600/'.$skladchina->images->first()->path) }} 600w">
                     <source type="image/webp" srcset="{{ asset('images/800/'.$skladchina->images->first()->path) }}">
                     <img
                         src="{{ asset('images/800/'.$skladchina->images->first()->path) }}"
-                        srcset="{{ asset('images/300/'.$skladchina->images->first()->path) }} 300w, {{ asset('images/800/'.$skladchina->images->first()->path) }} 800w"
+                        srcset="{{ asset('images/300/'.$skladchina->images->first()->path) }} 300w, {{ asset('images/600/'.$skladchina->images->first()->path) }} 600w, {{ asset('images/800/'.$skladchina->images->first()->path) }} 800w"
                         sizes="(max-width: 640px) 300px, 800px"
                         alt=""
                         loading="lazy"

--- a/resources/views/skladchinas/edit.blade.php
+++ b/resources/views/skladchinas/edit.blade.php
@@ -82,7 +82,7 @@
                     <label for="image" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Обложка (изображение)</label>
                     @if($skladchina->image_path)
                         <img src="{{ asset('images/800/'.$skladchina->image_path) }}"
-                             srcset="{{ asset('images/300/'.$skladchina->image_path) }} 300w, {{ asset('images/800/'.$skladchina->image_path) }} 800w"
+                             srcset="{{ asset('images/300/'.$skladchina->image_path) }} 300w, {{ asset('images/600/'.$skladchina->image_path) }} 600w, {{ asset('images/800/'.$skladchina->image_path) }} 800w"
                              sizes="(max-width: 640px) 300px, 800px"
                              alt="{{ $skladchina->name }}"
                              class="mb-2 w-full h-40 object-cover rounded"

--- a/resources/views/skladchinas/show.blade.php
+++ b/resources/views/skladchinas/show.blade.php
@@ -52,7 +52,7 @@
 @foreach($gallery as $img)
                         <img class="thumb w-16 h-16 object-cover rounded border-2 cursor-pointer {{ $loop->first ? 'border-blue-500 ring-2 ring-blue-300 dark:ring-blue-600' : 'border-transparent' }}"
                              data-src="/images/800/{{ $img }}"
-                             data-mobile-srcset="/images/300/{{ $img }} 300w, /images/800/{{ $img }} 800w, /images/1600/{{ $img }} 1600w"
+                             data-mobile-srcset="/images/300/{{ $img }} 300w, /images/600/{{ $img }} 600w, /images/800/{{ $img }} 800w, /images/1600/{{ $img }} 1600w"
                              data-alt="{{ $skladchina->title }} — Фото {{ $loop->iteration }}"
                              src="/images/100/{{ $img }}"
                              alt="{{ $skladchina->title }} — превью {{ $loop->iteration }}"


### PR DESCRIPTION
## Summary
- generate a 600px image size
- include 600px images in preload headers
- document the new size
- update picture sources and srcsets to use 300/600/800 widths

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486205be008328bdeca67bca6beaa8