### PR TITLE
Fix service worker fetch handling

### DIFF
--- a/public/serviceworker.js
+++ b/public/serviceworker.js
@@ -8,15 +8,24 @@ self.addEventListener('install', event => {
   );
 });
 self.addEventListener('fetch', event => {
+  if (event.request.cache === 'only-if-cached' && event.request.mode !== 'same-origin') {
+    return;
+  }
+
   event.respondWith(
-    fetch(event.request)
-      .then(response => {
-        const clone = response.clone();
-        caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
-        return response;
-      })
-      .catch(() => caches.match(event.request))
-    caches.match(event.request).then(resp => resp || fetch(event.request))
+    caches.match(event.request).then(cached => {
+      if (cached) {
+        return cached;
+      }
+
+      return fetch(event.request)
+        .then(response => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+          return response;
+        })
+        .catch(() => caches.match(event.request));
+    })
   );
 });
 self.addEventListener('push', event => {


### PR DESCRIPTION
## Summary
- fix `serviceworker.js` fetch handler to avoid `only-if-cached` error

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ff3008ec48328b8557564e3b2fc7c