### PR TITLE
Fix push subscription auth

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -344,6 +344,7 @@
                             'Content-Type': 'application/json',
                             'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
                         },
+                        credentials: 'same-origin',
                         body: JSON.stringify(sub)
                     }));
 


### PR DESCRIPTION
## Summary
- ensure cookies are sent when saving browser push subscriptions

## Testing
- `composer test` *(fails: MissingAppKeyException, Redis driver missing)*

------
https://chatgpt.com/codex/tasks/task_e_6850101ddbf88328a3d40173e6f3bf27