### PR TITLE
Fix push subscription auth

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -74,6 +74,7 @@ class AccountController extends Controller
             'notify_balance_changes' => $data['notify_balance_changes'] ?? false,
         ]);
 
-        return back();
+        return redirect()->route('account.notifications')
+            ->with('status', 'notifications-updated');
     }
 }

--- a/resources/views/account/notifications.blade.php
+++ b/resources/views/account/notifications.blade.php
@@ -6,6 +6,7 @@
     <div class="py-12">
         <div class="max-w-xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <x-auth-session-status class="mb-4" :status="session('status')" />
                 <form method="POST" action="{{ route('account.notifications.update') }}" class="space-y-4">
                     @csrf
                     <label class="flex items-center justify-between">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -335,20 +335,24 @@
                         return outputArray;
                     };
 
-                    const subscribe = () => reg.pushManager.subscribe({
-                        userVisibleOnly: true,
-                        applicationServerKey: urlBase64ToUint8Array('{{ config('webpush.vapid.public_key') }}')
-                    }).then(sub => fetch('{{ route('api.save-subscription') }}', {
+                    const sendSubscription = sub => fetch('{{ route('api.save-subscription') }}', {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
-                            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content
+                            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                            'Accept': 'application/json'
                         },
+                        credentials: 'include',
                         body: JSON.stringify(sub)
-                    }));
+                    });
+
+                    const subscribe = () => reg.pushManager.subscribe({
+                        userVisibleOnly: true,
+                        applicationServerKey: urlBase64ToUint8Array('{{ config('webpush.vapid.public_key') }}')
+                    }).then(sendSubscription);
 
                     if (Notification.permission === 'granted') {
-                        subscribe();
+                        reg.pushManager.getSubscription().then(ex => ex ? sendSubscription(ex) : subscribe());
                     } else if (Notification.permission !== 'denied') {
                         Notification.requestPermission().then(p => p === 'granted' && subscribe());
                     }


### PR DESCRIPTION
## Summary
- ensure cookies are sent when saving browser push subscriptions
- improve push subscription update logic
- tweak notifications form redirect

## Testing
- `composer test` *(fails: composer command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850101ddbf88328a3d40173e6f3bf27