### PR TITLE
Fix WebPushMessage usage

### DIFF
--- a/app/Notifications/BalanceChanged.php
+++ b/app/Notifications/BalanceChanged.php
@@ -22,7 +22,7 @@ class BalanceChanged extends Notification
 
     public function toWebPush(object $notifiable, object $notification): WebPushMessage
     {
-        return WebPushMessage::create()
+        return (new WebPushMessage)
             ->title('Движение баланса')
             ->icon('/icons/icon-192x192.png')
             ->body($this->description.' ('.number_format($this->amount,2,'',' ').' ₽)')

--- a/app/Notifications/NewSkladchina.php
+++ b/app/Notifications/NewSkladchina.php
@@ -23,12 +23,11 @@ class NewSkladchina extends Notification
             $channels[] = WebPushChannel::class;
         }
         return $channels;
-        return [WebPushChannel::class];
     }
 
     public function toWebPush(object $notifiable, object $notification): WebPushMessage
     {
-        return WebPushMessage::create()
+        return (new WebPushMessage)
             ->title('Новая складчина добавлена')
             ->icon('/icons/icon-192x192.png')
             ->body($this->skladchina->title)

--- a/app/Notifications/SiteNotification.php
+++ b/app/Notifications/SiteNotification.php
@@ -22,7 +22,7 @@ class SiteNotification extends Notification
 
     public function toWebPush(object $notifiable, object $notification): WebPushMessage
     {
-        return WebPushMessage::create()
+        return (new WebPushMessage)
             ->title($this->title)
             ->icon('/icons/icon-192x192.png')
             ->body($this->message)

--- a/app/Notifications/SkladchinaStatusChanged.php
+++ b/app/Notifications/SkladchinaStatusChanged.php
@@ -25,7 +25,7 @@ class SkladchinaStatusChanged extends Notification
 
     public function toWebPush(object $notifiable, object $notification): \NotificationChannels\WebPush\WebPushMessage
     {
-        return \NotificationChannels\WebPush\WebPushMessage::create()
+        return (new \NotificationChannels\WebPush\WebPushMessage)
             ->title('Изменен статус складчины')
             ->icon('/icons/icon-192x192.png')
             ->body($this->skladchina->name . ': ' . $this->skladchina->status_label)


### PR DESCRIPTION
## Summary
- fix notifications to use `(new WebPushMessage)` instead of the removed `::create()` method

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68501bfa74a8832892bb4f3ba7ed77ab