### PR TITLE
Fix guest response cache

### DIFF
--- a/app/CacheProfiles/CacheGuestGetRequests.php
+++ b/app/CacheProfiles/CacheGuestGetRequests.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\CacheProfiles;
+
+use Illuminate\Http\Request;
+use Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequests;
+
+/**
+ * Cache only successful GET requests for guests (unauthenticated users).
+ */
+class CacheGuestGetRequests extends CacheAllSuccessfulGetRequests
+{
+    public function shouldCacheRequest(Request $request): bool
+    {
+        if (auth()->check()) {
+            return false;
+        }
+
+        return parent::shouldCacheRequest($request);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -28,6 +28,8 @@ class AppServiceProvider extends ServiceProvider
     {
         Skladchina::observe(FlushResponseCacheObserver::class);
         User::observe(FlushResponseCacheObserver::class);
+        // Flush cached pages when categories change
+        Category::observe(FlushResponseCacheObserver::class);
 
         View::composer('*', function ($view) {
             if (Str::startsWith(Request::path(), 'admin')) {

--- a/config/responsecache.php
+++ b/config/responsecache.php
@@ -3,7 +3,8 @@
 return [
     'enabled' => env('RESPONSE_CACHE_ENABLED', true),
 
-    'cache_profile' => Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequests::class,
+    // Cache responses only for guests to avoid serving stale data to logged in users
+    'cache_profile' => App\CacheProfiles\CacheGuestGetRequests::class,
 
     'cache_bypass_header' => [
         'name' => env('CACHE_BYPASS_HEADER_NAME', null),


### PR DESCRIPTION
## Summary
- implement `CacheGuestGetRequests` profile
- use that profile in `responsecache` config
- flush cache when categories change

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850353651008328ada571aa7890ba43