### PR TITLE
Fix service worker caching

### DIFF
--- a/public/serviceworker.js
+++ b/public/serviceworker.js
@@ -8,6 +8,11 @@ self.addEventListener('install', event => {
   );
 });
 self.addEventListener('fetch', event => {
+  // Skip non-GET requests and requests with unsupported schemes
+  if (event.request.method !== 'GET' || !event.request.url.startsWith('http')) {
+    return;
+  }
+
   if (event.request.cache === 'only-if-cached' && event.request.mode !== 'same-origin') {
     return;
   }


### PR DESCRIPTION
## Summary
- ignore non-HTTP and non-GET requests in `serviceworker.js`

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850370593b88328b5ede39c19aef3b9