### PR TITLE
Fix login 419 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,7 @@ Images are generated in six resolutions: **100**, **200**, **300**, **600**,
 **800** and **1600** pixels. Desktop variants (800 and 1600) are encoded with quality
 **60**, while the smaller ones use quality **50**. Every size is saved in both
 AVIF and WebP formats.
+
+## Troubleshooting
+
+If you encounter HTTP 419 errors on the login page, response caching may have served a cached page without a proper session cookie. Clear the response cache using `php artisan responsecache:clear` and ensure the login page is excluded from caching.

--- a/app/CacheProfiles/CacheGuestGetRequests.php
+++ b/app/CacheProfiles/CacheGuestGetRequests.php
@@ -16,6 +16,10 @@ class CacheGuestGetRequests extends CacheAllSuccessfulGetRequests
             return false;
         }
 
+        if ($request->is('login') || $request->is('register')) {
+            return false;
+        }
+
         return parent::shouldCacheRequest($request);
     }
 }


### PR DESCRIPTION
## Summary
- exclude login and registration pages from response caching
- document how to clear cache when seeing 419 errors

## Testing
- `bash -lc 'composer test'` *(fails: composer not found)*


------
https://chatgpt.com/codex/tasks/task_e_68503cb9d0a48328a422a16e0905947e